### PR TITLE
Provide mock region in override file

### DIFF
--- a/bin/tflocal
+++ b/bin/tflocal
@@ -30,6 +30,7 @@ TF_PROVIDER_CONFIG = """
 provider "aws" {
   access_key                  = "test"
   secret_key                  = "test"
+  region                      = "us-east-1"
   skip_credentials_validation = true
   skip_metadata_api_check     = true
  endpoints {


### PR DESCRIPTION
When I follow https://docs.localstack.cloud/integrations/terraform/#deployment, `tflocal plan` / `tflocal apply` fail with:

```bash
$ tflocal apply
╷
│ Error: Invalid AWS Region: 
│ 
│   with provider["registry.terraform.io/hashicorp/aws"],
│   on localstack_providers_override.tf line 2, in provider "aws":
│    2: provider "aws" {
```

on [hashicorp/terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws) `4.14.0`.

➞ Provide a dummy region in the TF override file.