### PR TITLE
Add initial support for provider aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VENV_DIR ?= .venv
 VENV_RUN = . $(VENV_DIR)/bin/activate
 PIP_CMD ?= pip
+TEST_PATH ?= tests
 
 usage:        ## Show this help
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
@@ -14,7 +15,7 @@ lint:         ## Run code linter
 	$(VENV_RUN); flake8 --ignore=E501,W503 bin/tflocal tests
 
 test:         ## Run unit/integration tests
-	$(VENV_RUN); pytest $(PYTEST_ARGS) -sv tests
+	$(VENV_RUN); pytest $(PYTEST_ARGS) -sv $(TEST_PATH)
 
 publish:      ## Publish the library to the central PyPi repository
 	# build and upload archive

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -20,6 +20,7 @@ if os.path.isdir(os.path.join(PARENT_FOLDER, '.venv')):
     sys.path.insert(0, PARENT_FOLDER)
 
 from localstack_client import config  # noqa: E402
+import hcl2  # noqa: E402
 
 DEFAULT_REGION = "us-east-1"
 LOCALHOST_HOSTNAME = "localhost.localstack.cloud"
@@ -167,17 +168,16 @@ def to_str(obj) -> bytes:
 def determine_provider_aliases() -> list:
     """Return a list of providers (and aliases) configured in the *.tf files (if any)"""
     result = []
-    try:
-        import hcl2
-        for _file in glob.glob('*.tf'):
+    for _file in glob.glob('*.tf'):
+        try:
             with open(_file, 'r') as fp:
                 obj = hcl2.load(fp)
             providers = obj.get("provider", [])
             providers = [providers] if not isinstance(providers, list) else providers
             aws_providers = [prov["aws"] for prov in providers if prov.get("aws")]
             result.extend(aws_providers)
-    except Exception:
-        pass
+        except Exception as e:
+            print(f"Warning: Unable to extract providers from {_file}:", e)
     return result
 
 

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -12,6 +12,7 @@ your TF config.
 import os
 import re
 import sys
+import glob
 import subprocess
 
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
@@ -43,7 +44,9 @@ provider "aws" {
 PROCESS = None
 
 
-def create_provider_config_file():
+def create_provider_config_file(provider_aliases=None):
+    provider_aliases = provider_aliases or []
+
     # maps services to be replaced with alternative names
     service_replaces = {
         "apigatewaymanagementapi": "",
@@ -71,14 +74,28 @@ def create_provider_config_file():
             pass
     services = sorted(services)
 
-    # create config
-    endpoints = "\n".join([f'{s} = "{get_service_endpoint(s)}"' for s in services])
-    tf_config = TF_PROVIDER_CONFIG.replace("<endpoints>", endpoints)
-    additional_configs = []
-    if use_s3_path_style():
-        additional_configs += [" s3_use_path_style = true"]
-    additional_configs += [f' region = "{get_region()}"']
-    tf_config = tf_config.replace("<configs>", "\n".join(additional_configs))
+    # add default (non-aliased) provider, if not defined yet
+    default_provider = [p for p in provider_aliases if not p.get("alias")]
+    if not default_provider:
+        provider_aliases.append({"region": get_region()})
+
+    # create provider configs
+    provider_configs = []
+    for provider in provider_aliases:
+        endpoints = "\n".join([f'{s} = "{get_service_endpoint(s)}"' for s in services])
+        provider_config = TF_PROVIDER_CONFIG.replace("<endpoints>", endpoints)
+        additional_configs = []
+        if use_s3_path_style():
+            additional_configs += [" s3_use_path_style = true"]
+        if provider.get("alias"):
+            additional_configs += [f' alias = "{provider["alias"]}"']
+        region = provider.get("region") or get_region()
+        additional_configs += [f' region = "{region}"']
+        provider_config = provider_config.replace("<configs>", "\n".join(additional_configs))
+        provider_configs.append(provider_config)
+
+    # construct final config file content
+    tf_config = "\n".join(provider_configs)
 
     # write temporary config file
     providers_file = get_providers_file_path()
@@ -91,6 +108,7 @@ def create_provider_config_file():
 
 
 def get_providers_file_path() -> str:
+    """Determine the path under which the providers override file should be stored"""
     chdir = [arg for arg in sys.argv if arg.startswith("-chdir=")]
     base_dir = "."
     if chdir:
@@ -146,6 +164,23 @@ def to_str(obj) -> bytes:
     return obj.decode("UTF-8") if isinstance(obj, bytes) else obj
 
 
+def determine_provider_aliases() -> list:
+    """Return a list of providers (and aliases) configured in the *.tf files (if any)"""
+    result = []
+    try:
+        import hcl2
+        for _file in glob.glob('*.tf'):
+            with open(_file, 'r') as fp:
+                obj = hcl2.load(fp)
+            providers = obj.get("provider", [])
+            providers = [providers] if not isinstance(providers, list) else providers
+            aws_providers = [prov["aws"] for prov in providers if prov.get("aws")]
+            result.extend(aws_providers)
+    except Exception:
+        pass
+    return result
+
+
 def run_tf_exec(cmd, env):
     """Run terraform using os.exec - can be useful as it does not require any I/O
         handling for stdin/out/err. Does *not* allow us to perform any cleanup logic."""
@@ -175,7 +210,8 @@ def main():
     cmd = [TF_CMD] + sys.argv[1:]
 
     # create TF provider config file
-    config_file = create_provider_config_file()
+    providers = determine_provider_aliases()
+    config_file = create_provider_config_file(providers)
 
     # call terraform command
     try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.6
+version = 0.7
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud
@@ -26,6 +26,7 @@ packages = find:
 
 install_requires =
     localstack-client
+    python-hcl2
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Add initial support for Terraform [provider aliases](https://developer.hashicorp.com/terraform/language/providers/configuration#alias-multiple-provider-configurations). Addresses #11 

This allows deployment of TF resources that are linked to a provider alias, for example  in the snippet below the SQS queue `queue2` is linked to the provider alias `us_east_2`, whereas `queue1` is created for the default provider (in `eu-west-1` region). (see also the added test case in the PR)
```
    provider "aws" {
      region = "eu-west-1"
    }
    provider "aws" {
      alias  = "us_east_2"
      region = "us-east-2"
    }
    resource "aws_sqs_queue" "queue1" {
      name = "queue1"
    }
    resource "aws_sqs_queue" "queue2" {
      name = "queue2"
      provider = aws.us_east_2
    }
```

We are using the [python-hcl2](https://github.com/amplify-education/python-hcl2) library to parse `*.tf` files and look for `provider` entries. The library supports only version 2 of the Hashicorp Configuration Language (HCL2), which should be fine as by now this is the default and future-proof version of HCL.

As another side effect, the PR also enables using the correct region for default providers. In the example snippet above, the default provider defines `eu-west-1` as the target region - which would have caused a conflict with the current version of `tflocal` (prior to this PR), as we were determining the region from the credentials provider chain in the environment (e.g., `AWS_DEFAULT_REGION`). This is now working, and the correct region (`eu-west-1` in this case) is used for the default provider.

/cc @steffyP @macnev2013  @baermat