### PR TITLE
Create endpoint for opensearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ please refer to the man pages of `terraform --help`.
 
 ## Change Log
 
+* v0.8: Configure the endpoint for opensearch service
 * v0.7: Add initial support for provider aliases
 * v0.6: Fix selection of default region
 * v0.5: Make AWS region configurable, add `region` to provider config

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -56,7 +56,6 @@ def create_provider_config_file(provider_aliases=None):
         "iotdata": "",
         "iotjobsdata": "",
         "logs": "cloudwatchlogs",
-        "opensearch": "",
         "timestream": ""
     }
     # service names to be excluded (not yet available in TF)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.7
+version = 0.8
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud


### PR DESCRIPTION
Removed _opensearch_ from list of services to be replaced with alternative names, by doing this it automatically picks the default nature of services configured to point to the LocalStack API (http://localhost:4566)

Related to customer issue `support_grahambell_u05412jm3st`