### PR TITLE
Fix provider override configuration for emrserverless

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ please refer to the man pages of `terraform --help`.
 
 ## Change Log
 
+* v0.9: Fix unsupported provider override for emrserverless
 * v0.8: Configure the endpoint for opensearch service
 * v0.7: Add initial support for provider aliases
 * v0.6: Fix selection of default region

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -53,6 +53,7 @@ def create_provider_config_file(provider_aliases=None):
         "apigatewaymanagementapi": "",
         "ce": "costexplorer",
         "edge": "",
+        "emrserverless": "",
         "iotdata": "",
         "iotjobsdata": "",
         "logs": "cloudwatchlogs",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.8
+version = 0.9
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud


### PR DESCRIPTION
Fix provider override configuration for `emrserverless`. We've recently introduced the endpoint for `emrserverless` in the [localstack-python-client repo](https://github.com/localstack/localstack-python-client/pull/47) (which `tflocal` depends on), however, this endpoint is not (yet) available in the [TF provider overrides](https://registry.terraform.io/providers/hashicorp/aws/3.6.0/docs/guides/custom-service-endpoints#available-endpoint-customizations).

We're currently seeing this error with the latest versions (which is fixed via this PR):
```
$ tflocal apply
╷
│ Error: Unsupported argument
│
│   on localstack_providers_override.tf line 47, in provider "aws":
│   47: emrserverless = "http://localhost:4566"
│
│ An argument named "emrserverless" is not expected here.
```

/cc FYI @steffyP - looking to merge/release this asap now to unblock users, but wanted to ping you to keep you in the loop. 👍 thx