### PR TITLE
Fix parsed alias and region expressed as lists

### DIFF
--- a/bin/tflocal
+++ b/bin/tflocal
@@ -121,9 +121,7 @@ def create_provider_config_file(provider_aliases=None):
             region = region[0]
         additional_configs += [f' region = "{region}"']
         provider_config = provider_config.replace("<configs>", "\n".join(additional_configs))
-        provider_configs.append(provider_config) 
-
-    print("Using provider configs:", provider_configs)
+        provider_configs.append(provider_config)
 
     # construct final config file content
     tf_config = "\n".join(provider_configs)

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -111,12 +111,19 @@ def create_provider_config_file(provider_aliases=None):
         additional_configs = []
         if use_s3_path_style():
             additional_configs += [" s3_use_path_style = true"]
-        if provider.get("alias"):
-            additional_configs += [f' alias = "{provider["alias"]}"']
+        alias = provider.get("alias")
+        if alias:
+            if isinstance(alias, list):
+                alias = alias[0]
+            additional_configs += [f' alias = "{alias}"']
         region = provider.get("region") or get_region()
+        if isinstance(region, list):
+            region = region[0]
         additional_configs += [f' region = "{region}"']
         provider_config = provider_config.replace("<configs>", "\n".join(additional_configs))
-        provider_configs.append(provider_config)
+        provider_configs.append(provider_config) 
+
+    print("Using provider configs:", provider_configs)
 
     # construct final config file content
     tf_config = "\n".join(provider_configs)


### PR DESCRIPTION
The HCL2 library that is used to parse the provider block returns values as lists. This impacts `region` and `alias` values in the provider block and causes errors when running `tflocal`. This PR checks if these properties have been returned as lists, and extracts the initial element instead.