### PR TITLE
fix s3 path detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ please refer to the man pages of `terraform --help`.
 
 ## Change Log
 
+* v0.13: Fix S3 automatic `use_s3_path_style` detection when setting S3_HOSTNAME or LOCALSTACK_HOSTNAME
 * v0.12: Fix local endpoint overrides for Terraform AWS provider 5.9.0; fix parsing of alias and region defined as value lists
 * v0.11: Minor fix to handle boolean values in S3 backend configs
 * v0.10: Add support for storing state files in local S3 backends

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -10,10 +10,11 @@ your TF config.
 """
 
 import os
-import re
 import sys
 import glob
 import subprocess
+
+from urllib.parse import urlparse
 
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
 if os.path.isdir(os.path.join(PARENT_FOLDER, '.venv')):
@@ -212,9 +213,18 @@ def generate_s3_backend_config() -> str:
 # ---
 
 def use_s3_path_style() -> bool:
-    """Whether to use S3 path addressing (depending on the configured S3 endpoint)"""
-    regex = r"^[a-z]+://(localhost|[0-9.]+)(:[0-9]+)?$"
-    return bool(re.match(regex, get_service_endpoint("s3")))
+    """
+    Whether to use S3 path addressing (depending on the configured S3 endpoint)
+    If the endpoint starts with the `s3.` prefix, LocalStack will recognize virtual host addressing. If the endpoint
+    does not start with it, use path style. This also allows overriding the endpoint to always use path style in case of
+    inter container communications in Docker.
+    """
+    try:
+        host = urlparse(get_service_endpoint("s3")).hostname
+    except ValueError:
+        host = ""
+
+    return not host.startswith("s3.")
 
 
 def get_region() -> str:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.12
+version = 0.13
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -34,6 +34,16 @@ def test_use_s3_path_style(monkeypatch):
     import_cli_code()
     assert use_s3_path_style()  # noqa
 
+    # test the case where the S3_HOSTNAME could be a Docker container name
+    monkeypatch.setenv("S3_HOSTNAME", "localstack")
+    import_cli_code()
+    assert use_s3_path_style()  # noqa
+
+    # test the case where the S3_HOSTNAME could be an arbitrary host starting with `s3.`
+    monkeypatch.setenv("S3_HOSTNAME", "s3.internal.host")
+    import_cli_code()
+    assert not use_s3_path_style()  # noqa
+
 
 def test_provider_aliases(monkeypatch):
     queue_name1 = f"q{short_uid()}"


### PR DESCRIPTION
This PR would fix #26, or at least propose an easy workaround by setting `S3_HOSTNAME=localstack` while deploying with `tflocal`, which would force it to use `s3_path_style=true`. Right now, there's no easy way to force `tflocal` to use path style automatically except by setting the S3 endpoint to `localhost`.

I've improved the detection to be in line with LocalStack, where any request not starting with the `s3.` prefix would not be considered `virtual host` and would fail. 