### PR TITLE
Add support to multi-account environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,114 @@ dist/
 *.pyc
 __pycache__/
 
-.vscode
+# Created by https://www.toptal.com/developers/gitignore/api/pycharm+all,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=pycharm+all,visualstudiocode
+
+### PyCharm+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### PyCharm+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/pycharm+all,visualstudiocode

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 
 *.pyc
 __pycache__/
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ The following environment variables can be configured:
 The `tflocal` command has the same usage as the `terraform` command. For detailed usage,
 please refer to the man pages of `terraform --help`.
 
-## TODO
-- [ ] Sync region and access key override behavior
-
 ## Change Log
 
 * v0.14: Add support to multi-account environments

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The following environment variables can be configured:
 The `tflocal` command has the same usage as the `terraform` command. For detailed usage,
 please refer to the man pages of `terraform --help`.
 
+## TODO
+- [ ] Sync region and access key override behavior
+
 ## Change Log
 
 * v0.14: Add support to multi-account environments

--- a/README.md
+++ b/README.md
@@ -31,8 +31,14 @@ The following environment variables can be configured:
 * `USE_EXEC`: whether to use `os.exec` instead of `subprocess.Popen` (try using this in case of I/O issues)
 * `<SERVICE>_ENDPOINT`: setting a custom service endpoint, e.g., `COGNITO_IDP_ENDPOINT=http://example.com`
 * `AWS_DEFAULT_REGION`: the AWS region to use (default: `us-east-1`, or determined from local credentials if `boto3` is installed)
-* `CUSTOMISE_ACCESS_KEY`: enables to override the static AWS Access Key ID
-* `AWS_ACCESS_KEY_ID`: the AWS Access Key ID to use for multi account setups, (default: `test`, or determined from local credentials if `CUSTOMISE_ACCESS_KEY=1`, `boto3` is installed and credentials are set, if either of the `AWS_PROFILE` or `AWS_DEFAULT_PROFILE` variables set, it uses the respective profile, default is `default`)
+* `CUSTOMISE_ACCESS_KEY`: enables to override the static AWS Access Key ID. The following cases are taking precedence over each other from top to bottom:
+    * `AWS_ACCESS_KEY_ID` environment variable is set
+    * `access_key` is set in the Terraform AWS provider
+    * `AWS_PROFILE` environment variable is set and configured
+    * `AWS_DEFAULT_PROFILE` environment variable is set and configured
+    * `default` profile's credentials are configured
+    * falls back to the default `AWS_ACCESS_KEY_ID` mock value
+* `AWS_ACCESS_KEY_ID`: AWS Access Key ID to use for multi account setups (default: `test` -> account ID: `000000000000`)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The following environment variables can be configured:
 * `USE_EXEC`: whether to use `os.exec` instead of `subprocess.Popen` (try using this in case of I/O issues)
 * `<SERVICE>_ENDPOINT`: setting a custom service endpoint, e.g., `COGNITO_IDP_ENDPOINT=http://example.com`
 * `AWS_DEFAULT_REGION`: the AWS region to use (default: `us-east-1`, or determined from local credentials if `boto3` is installed)
+* `CUSTOMISE_ACCESS_KEY`: enables to override the static AWS Access Key ID
+* `AWS_ACCESS_KEY_ID`: the AWS Access Key ID to use for multi account setups, (default: `test`, or determined from local credentials if `CUSTOMISE_ACCESS_KEY=1`, `boto3` is installed and credentials are set, if either of the `AWS_PROFILE` or `AWS_DEFAULT_PROFILE` variables set, it uses the respective profile, default is `default`)
 
 ## Usage
 
@@ -39,6 +41,7 @@ please refer to the man pages of `terraform --help`.
 
 ## Change Log
 
+* v0.14: Add support to multi-account environments
 * v0.13: Fix S3 automatic `use_s3_path_style` detection when setting S3_HOSTNAME or LOCALSTACK_HOSTNAME
 * v0.12: Fix local endpoint overrides for Terraform AWS provider 5.9.0; fix parsing of alias and region defined as value lists
 * v0.11: Minor fix to handle boolean values in S3 backend configs

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following environment variables can be configured:
 * `USE_EXEC`: whether to use `os.exec` instead of `subprocess.Popen` (try using this in case of I/O issues)
 * `<SERVICE>_ENDPOINT`: setting a custom service endpoint, e.g., `COGNITO_IDP_ENDPOINT=http://example.com`
 * `AWS_DEFAULT_REGION`: the AWS region to use (default: `us-east-1`, or determined from local credentials if `boto3` is installed)
-* `CUSTOMISE_ACCESS_KEY`: enables to override the static AWS Access Key ID. The following cases are taking precedence over each other from top to bottom:
+* `CUSTOMIZE_ACCESS_KEY`: enables to override the static AWS Access Key ID. The following cases are taking precedence over each other from top to bottom:
     * `AWS_ACCESS_KEY_ID` environment variable is set
     * `access_key` is set in the Terraform AWS provider
     * `AWS_PROFILE` environment variable is set and configured

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -25,7 +25,7 @@ import hcl2  # noqa: E402
 
 DEFAULT_REGION = "us-east-1"
 DEFAULT_ACCESS_KEY = "test"
-CUSTOMISE_ACCESS_KEY = os.environ.get("CUSTOMISE_ACCESS_KEY") == '1'
+CUSTOMISE_ACCESS_KEY = str(os.environ.get("CUSTOMISE_ACCESS_KEY")).strip().lower() in ["1", "true"]
 LOCALHOST_HOSTNAME = "localhost.localstack.cloud"
 S3_HOSTNAME = os.environ.get("S3_HOSTNAME") or f"s3.{LOCALHOST_HOSTNAME}"
 USE_EXEC = str(os.environ.get("USE_EXEC")).strip().lower() in ["1", "true"]

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -25,7 +25,7 @@ import hcl2  # noqa: E402
 
 DEFAULT_REGION = "us-east-1"
 DEFAULT_ACCESS_KEY = "test"
-CUSTOMISE_ACCESS_KEY = str(os.environ.get("CUSTOMISE_ACCESS_KEY")).strip().lower() in ["1", "true"]
+CUSTOMIZE_ACCESS_KEY = str(os.environ.get("CUSTOMIZE_ACCESS_KEY")).strip().lower() in ["1", "true"]
 LOCALHOST_HOSTNAME = "localhost.localstack.cloud"
 S3_HOSTNAME = os.environ.get("S3_HOSTNAME") or f"s3.{LOCALHOST_HOSTNAME}"
 USE_EXEC = str(os.environ.get("USE_EXEC")).strip().lower() in ["1", "true"]
@@ -118,12 +118,12 @@ def create_provider_config_file(provider_aliases=None):
     # create provider configs
     provider_configs = []
     for provider in provider_aliases:
-        endpoints = "\n".join([f'{s} = "{get_service_endpoint(s)}"' for s in services])
-        provider_config = TF_PROVIDER_CONFIG.replace("<endpoints>", endpoints)
-        provider_config = provider_config.replace(
+        provider_config = TF_PROVIDER_CONFIG.replace(
             "<access_key>",
-            get_access_key(provider) if CUSTOMISE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+            get_access_key(provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
         )
+        endpoints = "\n".join([f'{s} = "{get_service_endpoint(s)}"' for s in services])
+        provider_config = provider_config.replace("<endpoints>", endpoints)
         additional_configs = []
         if use_s3_path_style():
             additional_configs += [" s3_use_path_style = true"]
@@ -249,7 +249,7 @@ def get_region() -> str:
     return region or DEFAULT_REGION
 
 
-def get_access_key(provider=None) -> str:
+def get_access_key(provider: dict) -> str:
     access_key = str(os.environ.get("AWS_ACCESS_KEY_ID") or provider.get("access_key", "")).strip()
     if access_key and access_key != DEFAULT_ACCESS_KEY:
         # Change live access key to mocked one
@@ -259,15 +259,16 @@ def get_access_key(provider=None) -> str:
         # Note that boto3 is currently not included in the dependencies, to
         # keep the library lightweight.
         import boto3
-        profile = str(os.environ.get("AWS_PROFILE") or os.environ.get("AWS_DEFAULT_PROFILE", "default")).strip()
-        access_key = boto3.session.Session(profile_name=profile).get_credentials().access_key
+        access_key = boto3.session.Session().get_credentials().access_key
     except Exception:
         pass
     # fall back to default region
     return deactivate_access_key(access_key or DEFAULT_ACCESS_KEY)
 
 
-def deactivate_access_key(access_key) -> str:
+def deactivate_access_key(access_key: str) -> str:
+    """Safe guarding user from accidental live credential usage by deactivating access key IDs.
+        See more: https://docs.localstack.cloud/references/credentials/"""
     return "L" + access_key[1:] if access_key[0] == "A" else access_key
 
 

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -122,7 +122,7 @@ def create_provider_config_file(provider_aliases=None):
         provider_config = TF_PROVIDER_CONFIG.replace("<endpoints>", endpoints)
         provider_config = provider_config.replace(
             "<access_key>",
-            get_access_key() if CUSTOMISE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+            get_access_key(provider) if CUSTOMISE_ACCESS_KEY else DEFAULT_ACCESS_KEY
         )
         additional_configs = []
         if use_s3_path_style():
@@ -248,21 +248,28 @@ def get_region() -> str:
     # fall back to default region
     return region or DEFAULT_REGION
 
-def get_access_key() -> str:
-    profile = str(os.environ.get("AWS_PROFILE") or os.environ.get("AWS_DEFAULT_PROFILE") or "default").strip()
-    access_key = str(os.environ.get("AWS_ACCESS_KEY_ID") or "").strip()
-    if access_key:
-        return access_key
+
+def get_access_key(provider=None) -> str:
+    access_key = str(os.environ.get("AWS_ACCESS_KEY_ID") or provider.get("access_key", "")).strip()
+    if access_key and access_key != DEFAULT_ACCESS_KEY:
+        # Change live access key to mocked one
+        return deactivate_access_key(access_key)
     try:
         # If boto3 is installed, try to get the access_key from local credentials.
         # Note that boto3 is currently not included in the dependencies, to
         # keep the library lightweight.
         import boto3
+        profile = str(os.environ.get("AWS_PROFILE") or os.environ.get("AWS_DEFAULT_PROFILE", "default")).strip()
         access_key = boto3.session.Session(profile_name=profile).get_credentials().access_key
     except Exception:
         pass
     # fall back to default region
-    return access_key or DEFAULT_ACCESS_KEY
+    return deactivate_access_key(access_key or DEFAULT_ACCESS_KEY)
+
+
+def deactivate_access_key(access_key) -> str:
+    return "L" + access_key[1:] if access_key[0] == "A" else access_key
+
 
 def get_service_endpoint(service: str) -> str:
     """Get the service endpoint URL for the given service name"""

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -24,6 +24,8 @@ from localstack_client import config  # noqa: E402
 import hcl2  # noqa: E402
 
 DEFAULT_REGION = "us-east-1"
+DEFAULT_ACCESS_KEY = "test"
+CUSTOMISE_ACCESS_KEY = os.environ.get("CUSTOMISE_ACCESS_KEY") == '1'
 LOCALHOST_HOSTNAME = "localhost.localstack.cloud"
 S3_HOSTNAME = os.environ.get("S3_HOSTNAME") or f"s3.{LOCALHOST_HOSTNAME}"
 USE_EXEC = str(os.environ.get("USE_EXEC")).strip().lower() in ["1", "true"]
@@ -33,7 +35,7 @@ LOCALSTACK_HOSTNAME = os.environ.get("LOCALSTACK_HOSTNAME") or "localhost"
 EDGE_PORT = int(os.environ.get("EDGE_PORT") or 4566)
 TF_PROVIDER_CONFIG = """
 provider "aws" {
-  access_key                  = "test"
+  access_key                  = "<access_key>"
   secret_key                  = "test"
   skip_credentials_validation = true
   skip_metadata_api_check     = true
@@ -118,6 +120,10 @@ def create_provider_config_file(provider_aliases=None):
     for provider in provider_aliases:
         endpoints = "\n".join([f'{s} = "{get_service_endpoint(s)}"' for s in services])
         provider_config = TF_PROVIDER_CONFIG.replace("<endpoints>", endpoints)
+        provider_config = provider_config.replace(
+            "<access_key>",
+            get_access_key() if CUSTOMISE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+        )
         additional_configs = []
         if use_s3_path_style():
             additional_configs += [" s3_use_path_style = true"]
@@ -242,6 +248,21 @@ def get_region() -> str:
     # fall back to default region
     return region or DEFAULT_REGION
 
+def get_access_key() -> str:
+    profile = str(os.environ.get("AWS_PROFILE") or os.environ.get("AWS_DEFAULT_PROFILE") or "default").strip()
+    access_key = str(os.environ.get("AWS_ACCESS_KEY_ID") or "").strip()
+    if access_key:
+        return access_key
+    try:
+        # If boto3 is installed, try to get the access_key from local credentials.
+        # Note that boto3 is currently not included in the dependencies, to
+        # keep the library lightweight.
+        import boto3
+        access_key = boto3.session.Session(profile_name=profile).get_credentials().access_key
+    except Exception:
+        pass
+    # fall back to default region
+    return access_key or DEFAULT_ACCESS_KEY
 
 def get_service_endpoint(service: str) -> str:
     """Get the service endpoint URL for the given service name"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.13
+version = 0.14
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,10 +1,11 @@
-import tempfile
 import os
-import boto3
-import uuid
 import random
 import subprocess
+import tempfile
+import uuid
 from typing import Dict
+
+import boto3
 
 THIS_PATH = os.path.abspath(os.path.dirname(__file__))
 ROOT_PATH = os.path.join(THIS_PATH, "..")
@@ -12,32 +13,33 @@ TFLOCAL_BIN = os.path.join(ROOT_PATH, "bin", "tflocal")
 LOCALSTACK_ENDPOINT = "http://localhost:4566"
 
 
-# def test_access_key_override_fallback(monkeypatch):
-#     access_key = f"{mock_access_key()}"
-#     monkeypatch.setenv("AWS_ACCESS_KEY_ID", access_key)
-#     bucket_name = f"{short_uid()}"
-#     config = """
-#     provider "aws" {
-#       region = "eu-west-1"
-#     }
-#     resource "aws_s3_bucket" "test_bucket" {
-#       bucket = "%s"
-#     }""" % (bucket_name)
-#     deploy_tf_script(config)
+def test_access_key_override_fallback(monkeypatch):
+    access_key = f"{mock_access_key()}"
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", access_key)
+    bucket_name = f"{short_uid()}"
+    config = """
+    provider "aws" {
+      region = "eu-west-1"
+    }
+    resource "aws_s3_bucket" "test_bucket" {
+      bucket = "%s"
+    }""" % (bucket_name)
+    deploy_tf_script(config)
 
-#     s3 = client("s3", region_name="eu-west-1")
-#     s3_buckets = s3.list_buckets().get("Buckets")
-#     s3_bucket_names = [s["Name"] for s in s3_buckets]
+    s3 = client("s3", region_name="eu-west-1")
+    s3_buckets = s3.list_buckets().get("Buckets")
+    s3_bucket_names = [s["Name"] for s in s3_buckets]
 
-#     assert bucket_name in s3_bucket_names
+    assert bucket_name in s3_bucket_names
 
-#     s3 = client("s3", region_name="eu-west-1", aws_access_key_id=access_key)
-#     s3_buckets = s3.list_buckets().get("Buckets")
-#     s3_bucket_names = [s["Name"] for s in s3_buckets]
+    s3 = client("s3", region_name="eu-west-1", aws_access_key_id=access_key)
+    s3_buckets = s3.list_buckets().get("Buckets")
+    s3_bucket_names = [s["Name"] for s in s3_buckets]
 
-#     assert bucket_name not in s3_bucket_names
+    assert bucket_name not in s3_bucket_names
 
 
+# @pytest.mark.skip()
 def test_access_key_override_by_env_var(monkeypatch):
     monkeypatch.setenv("CUSTOMISE_ACCESS_KEY", "1")
     access_key = f"{mock_access_key()}"
@@ -93,12 +95,13 @@ def test_access_key_override_by_profile(monkeypatch):
         }""" % (bucket_name)
         deploy_tf_script(config)
 
-        s3 = client("s3", region_name="eu-west-1", profile_name=profile_name)
+        s3 = client("s3", region_name="eu-west-1")
         s3_buckets = s3.list_buckets().get("Buckets")
         s3_bucket_names = [s["Name"] for s in s3_buckets]
 
         assert bucket_name in s3_bucket_names
 
+        monkeypatch.delenv("AWS_PROFILE")
         s3 = client("s3", region_name="eu-west-1")
         s3_buckets = s3.list_buckets().get("Buckets")
         s3_bucket_names = [s["Name"] for s in s3_buckets]
@@ -138,7 +141,7 @@ def test_access_key_override_by_default_profile(monkeypatch):
 
         assert bucket_name not in s3_bucket_names
 
-        s3 = client("s3", region_name="eu-west-1", profile_name="default")
+        s3 = client("s3", region_name="eu-west-1", aws_access_key_id=None, aws_secret_access_key=None)
         s3_buckets = s3.list_buckets().get("Buckets")
         s3_bucket_names = [s["Name"] for s in s3_buckets]
 
@@ -172,105 +175,105 @@ def test_access_key_override_by_provider(monkeypatch):
     assert bucket_name in s3_bucket_names
 
 
-# def test_s3_path_addressing():
-#     bucket_name = f"bucket.{short_uid()}"
-#     config = """
-#     resource "aws_s3_bucket" "test-bucket" {
-#       bucket = "%s"
-#     }
-#     """ % bucket_name
-#     deploy_tf_script(config, env_vars={"S3_HOSTNAME": "localhost"})
+def test_s3_path_addressing():
+    bucket_name = f"bucket.{short_uid()}"
+    config = """
+    resource "aws_s3_bucket" "test-bucket" {
+      bucket = "%s"
+    }
+    """ % bucket_name
+    deploy_tf_script(config, env_vars={"S3_HOSTNAME": "localhost"})
 
-#     s3 = client("s3")
-#     buckets = [b["Name"] for b in s3.list_buckets()["Buckets"]]
-#     assert bucket_name in buckets
-
-
-# def test_use_s3_path_style(monkeypatch):
-#     monkeypatch.setenv("S3_HOSTNAME", "s3.localhost.localstack.cloud")
-#     import_cli_code()
-#     assert not use_s3_path_style()  # noqa
-
-#     monkeypatch.setenv("S3_HOSTNAME", "localhost")
-#     import_cli_code()
-#     assert use_s3_path_style()  # noqa
-
-#     # test the case where the S3_HOSTNAME could be a Docker container name
-#     monkeypatch.setenv("S3_HOSTNAME", "localstack")
-#     import_cli_code()
-#     assert use_s3_path_style()  # noqa
-
-#     # test the case where the S3_HOSTNAME could be an arbitrary host starting with `s3.`
-#     monkeypatch.setenv("S3_HOSTNAME", "s3.internal.host")
-#     import_cli_code()
-#     assert not use_s3_path_style()  # noqa
+    s3 = client("s3")
+    buckets = [b["Name"] for b in s3.list_buckets()["Buckets"]]
+    assert bucket_name in buckets
 
 
-# def test_provider_aliases():
-#     queue_name1 = f"q{short_uid()}"
-#     queue_name2 = f"q{short_uid()}"
-#     config = """
-#     provider "aws" {
-#       region = "eu-west-1"
-#     }
-#     provider "aws" {
-#       alias  = "us_east_2"
-#       region = "us-east-2"
-#     }
-#     resource "aws_sqs_queue" "queue1" {
-#       name = "%s"
-#     }
-#     resource "aws_sqs_queue" "queue2" {
-#       name = "%s"
-#       provider = aws.us_east_2
-#     }
-#     """ % (queue_name1, queue_name2)
-#     deploy_tf_script(config)
+def test_use_s3_path_style(monkeypatch):
+    monkeypatch.setenv("S3_HOSTNAME", "s3.localhost.localstack.cloud")
+    import_cli_code()
+    assert not use_s3_path_style()  # noqa
 
-#     sqs1 = client("sqs", region_name="eu-west-1")
-#     sqs2 = client("sqs", region_name="us-east-2")
-#     queues1 = [q for q in sqs1.list_queues().get("QueueUrls", [])]
-#     queues2 = [q for q in sqs2.list_queues().get("QueueUrls", [])]
-#     assert any(queue_name1 in queue_url for queue_url in queues1)
-#     assert any(queue_name2 in queue_url for queue_url in queues2)
+    monkeypatch.setenv("S3_HOSTNAME", "localhost")
+    import_cli_code()
+    assert use_s3_path_style()  # noqa
+
+    # test the case where the S3_HOSTNAME could be a Docker container name
+    monkeypatch.setenv("S3_HOSTNAME", "localstack")
+    import_cli_code()
+    assert use_s3_path_style()  # noqa
+
+    # test the case where the S3_HOSTNAME could be an arbitrary host starting with `s3.`
+    monkeypatch.setenv("S3_HOSTNAME", "s3.internal.host")
+    import_cli_code()
+    assert not use_s3_path_style()  # noqa
 
 
-# def test_s3_backend():
-#     state_bucket = f"tf-state-{short_uid()}"
-#     state_table = f"tf-state-{short_uid()}"
-#     bucket_name = f"bucket.{short_uid()}"
-#     config = """
-#     terraform {
-#       backend "s3" {
-#         bucket = "%s"
-#         key    = "terraform.tfstate"
-#         dynamodb_table = "%s"
-#         region = "us-east-2"
-#         skip_credentials_validation = true
-#       }
-#     }
-#     resource "aws_s3_bucket" "test-bucket" {
-#       bucket = "%s"
-#     }
-#     """ % (state_bucket, state_table, bucket_name)
-#     deploy_tf_script(config)
+def test_provider_aliases():
+    queue_name1 = f"q{short_uid()}"
+    queue_name2 = f"q{short_uid()}"
+    config = """
+    provider "aws" {
+      region = "eu-west-1"
+    }
+    provider "aws" {
+      alias  = "us_east_2"
+      region = "us-east-2"
+    }
+    resource "aws_sqs_queue" "queue1" {
+      name = "%s"
+    }
+    resource "aws_sqs_queue" "queue2" {
+      name = "%s"
+      provider = aws.us_east_2
+    }
+    """ % (queue_name1, queue_name2)
+    deploy_tf_script(config)
 
-#     # assert that bucket with state file exists
-#     s3 = client("s3", region_name="us-east-2")
-#     result = s3.list_objects(Bucket=state_bucket)
-#     keys = [obj["Key"] for obj in result["Contents"]]
-#     assert "terraform.tfstate" in keys
+    sqs1 = client("sqs", region_name="eu-west-1")
+    sqs2 = client("sqs", region_name="us-east-2")
+    queues1 = [q for q in sqs1.list_queues().get("QueueUrls", [])]
+    queues2 = [q for q in sqs2.list_queues().get("QueueUrls", [])]
+    assert any(queue_name1 in queue_url for queue_url in queues1)
+    assert any(queue_name2 in queue_url for queue_url in queues2)
 
-#     # assert that DynamoDB table with state file locks exists
-#     dynamodb = client("dynamodb", region_name="us-east-2")
-#     result = dynamodb.describe_table(TableName=state_table)
-#     attrs = result["Table"]["AttributeDefinitions"]
-#     assert attrs == [{"AttributeName": "LockID", "AttributeType": "S"}]
 
-#     # assert that S3 resource has been created
-#     s3 = client("s3")
-#     result = s3.head_bucket(Bucket=bucket_name)
-#     assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
+def test_s3_backend():
+    state_bucket = f"tf-state-{short_uid()}"
+    state_table = f"tf-state-{short_uid()}"
+    bucket_name = f"bucket.{short_uid()}"
+    config = """
+    terraform {
+      backend "s3" {
+        bucket = "%s"
+        key    = "terraform.tfstate"
+        dynamodb_table = "%s"
+        region = "us-east-2"
+        skip_credentials_validation = true
+      }
+    }
+    resource "aws_s3_bucket" "test-bucket" {
+      bucket = "%s"
+    }
+    """ % (state_bucket, state_table, bucket_name)
+    deploy_tf_script(config)
+
+    # assert that bucket with state file exists
+    s3 = client("s3", region_name="us-east-2")
+    result = s3.list_objects(Bucket=state_bucket)
+    keys = [obj["Key"] for obj in result["Contents"]]
+    assert "terraform.tfstate" in keys
+
+    # assert that DynamoDB table with state file locks exists
+    dynamodb = client("dynamodb", region_name="us-east-2")
+    result = dynamodb.describe_table(TableName=state_table)
+    attrs = result["Table"]["AttributeDefinitions"]
+    assert attrs == [{"AttributeName": "LockID", "AttributeType": "S"}]
+
+    # assert that S3 resource has been created
+    s3 = client("s3")
+    result = s3.head_bucket(Bucket=bucket_name)
+    assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
 
 
 ###
@@ -296,18 +299,16 @@ def mock_access_key() -> str:
     return str(random.randrange(999999999999)).zfill(12)
 
 
-def client(service: str, aws_access_key_id="test", aws_secret_access_key="test", **kwargs):
-    if "profile_name" in kwargs:
-        session = boto3.session.Session(
-            **kwargs,
-        )
-        aws_access_key_id = session.get_credentials().access_key
-        aws_secret_access_key = session.get_credentials().secret_key
-        del kwargs["profile_name"]
+def client(service: str, **kwargs):
+    # if aws access key is not set AND no profile is in the environment,
+    # we want to set the accesss key and the secret key to test
+    if "aws_access_key_id" not in kwargs and "AWS_PROFILE" not in os.environ:
+        kwargs["aws_access_key_id"] = "test"
+    if "aws_access_key_id" in kwargs and "aws_secret_access_key" not in kwargs:
+        kwargs["aws_secret_access_key"] = "test"
+    boto3.setup_default_session()
     return boto3.client(
         service,
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
         endpoint_url=LOCALSTACK_ENDPOINT,
         **kwargs,
     )

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -39,7 +39,6 @@ def test_access_key_override_fallback(monkeypatch):
     assert bucket_name not in s3_bucket_names
 
 
-# @pytest.mark.skip()
 def test_access_key_override_by_env_var(monkeypatch):
     monkeypatch.setenv("CUSTOMISE_ACCESS_KEY", "1")
     access_key = f"{mock_access_key()}"

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -14,9 +14,9 @@ LOCALSTACK_ENDPOINT = "http://localhost:4566"
 
 
 def test_access_key_override_fallback(monkeypatch):
-    access_key = f"{mock_access_key()}"
+    access_key = mock_access_key()
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", access_key)
-    bucket_name = f"{short_uid()}"
+    bucket_name = short_uid()
     config = """
     provider "aws" {
       region = "eu-west-1"
@@ -40,10 +40,10 @@ def test_access_key_override_fallback(monkeypatch):
 
 
 def test_access_key_override_by_env_var(monkeypatch):
-    monkeypatch.setenv("CUSTOMISE_ACCESS_KEY", "1")
-    access_key = f"{mock_access_key()}"
+    monkeypatch.setenv("CUSTOMIZE_ACCESS_KEY", "1")
+    access_key = mock_access_key()
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", access_key)
-    bucket_name = f"{short_uid()}"
+    bucket_name = short_uid()
     config = """
     provider "aws" {
       region = "eu-west-1"
@@ -67,11 +67,11 @@ def test_access_key_override_by_env_var(monkeypatch):
 
 
 def test_access_key_override_by_profile(monkeypatch):
-    profile_name = f"{short_uid()}"
-    monkeypatch.setenv("CUSTOMISE_ACCESS_KEY", "1")
+    profile_name = short_uid()
+    monkeypatch.setenv("CUSTOMIZE_ACCESS_KEY", "1")
     monkeypatch.setenv("AWS_PROFILE", profile_name)
-    access_key = f"{mock_access_key()}"
-    bucket_name = f"{short_uid()}"
+    access_key = mock_access_key()
+    bucket_name = short_uid()
     credentials = """
     [%s]
     aws_access_key_id = %s
@@ -109,9 +109,9 @@ def test_access_key_override_by_profile(monkeypatch):
 
 
 def test_access_key_override_by_default_profile(monkeypatch):
-    monkeypatch.setenv("CUSTOMISE_ACCESS_KEY", "1")
-    access_key = f"{mock_access_key()}"
-    bucket_name = f"{short_uid()}"
+    monkeypatch.setenv("CUSTOMIZE_ACCESS_KEY", "1")
+    access_key = mock_access_key()
+    bucket_name = short_uid()
     credentials = """
     [default]
     aws_access_key_id = %s
@@ -148,9 +148,9 @@ def test_access_key_override_by_default_profile(monkeypatch):
 
 
 def test_access_key_override_by_provider(monkeypatch):
-    monkeypatch.setenv("CUSTOMISE_ACCESS_KEY", "1")
-    access_key = f"{mock_access_key()}"
-    bucket_name = f"{short_uid()}"
+    monkeypatch.setenv("CUSTOMIZE_ACCESS_KEY", "1")
+    access_key = mock_access_key()
+    bucket_name = short_uid()
     config = """
     provider "aws" {
       access_key = "%s"


### PR DESCRIPTION
# Motivation
tflocal is only usable currently with a single account as all resources are deployed into the default one. This behavior is not ideal to run tests or develop code for many production cases when terraform code references to resources outside of this account ie to manage a domain registration or validate certificates on a central DNS managing account.

Related issue: #29

# Changes
- Added new env variable to trigger look up for provided possible override values instead of the mocked access key
- Added tests regarding above functionality

# TODO
- [x] Trigger predefined access key usage for `CUSTOMISE_ACCESS_KEY=1`
- [x] Use AWS_ACCESS_KEY_ID environment variable
- [x] Use boto3 to get ACCESS_KEY_ID from default session
- [x] Use AWS_PROFILE or AWS_DEFAULT_PROFILE variable to get access key
- [x] Use access key from Terraform files
- [x] ~Import original arguments into the mock file~
- [x] Test above use cases and edge cases
- [x] Sync region and access key behavior