### PR TITLE
fix disable endpoiint config for appconfigdata

### DIFF
--- a/bin/tflocal
+++ b/bin/tflocal
@@ -76,6 +76,7 @@ def create_provider_config_file(provider_aliases=None):
 
     # maps services to be replaced with alternative names
     service_replaces = {
+        "appconfigdata": "",
         "apigatewaymanagementapi": "",
         "ce": "costexplorer",
         "edge": "",


### PR DESCRIPTION
https://github.com/localstack/localstack-python-client/pull/50 introduced a new service in our client library.
This PR disables this service, as it does not have a terraform provider implementation yet.

Fixes https://github.com/localstack/terraform-local/issues/31.
/cc @lakkeger 