### PR TITLE
Support force_path_style in s3 backend overrides

### DIFF
--- a/bin/tflocal
+++ b/bin/tflocal
@@ -61,7 +61,7 @@ terraform {
     dynamodb_endpoint = "<dynamodb_endpoint>"
     skip_credentials_validation = true
     skip_metadata_api_check     = true
-    use_path_style              = <use_path_style>
+    force_path_style            = <force_path_style>
   }
 }
 """
@@ -207,7 +207,7 @@ def generate_s3_backend_config() -> str:
         "iam_endpoint": get_service_endpoint("iam"),
         "sts_endpoint": get_service_endpoint("sts"),
         "dynamodb_endpoint": get_service_endpoint("dynamodb"),
-        "use_path_style": bool(use_s3_path_style()),
+        "force_path_style": bool(use_s3_path_style()),
     }
     configs.update(backend_config)
     get_or_create_bucket(configs["bucket"])

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -61,6 +61,7 @@ terraform {
     dynamodb_endpoint = "<dynamodb_endpoint>"
     skip_credentials_validation = true
     skip_metadata_api_check     = true
+    use_path_style              = <use_path_style>
   }
 }
 """
@@ -206,6 +207,7 @@ def generate_s3_backend_config() -> str:
         "iam_endpoint": get_service_endpoint("iam"),
         "sts_endpoint": get_service_endpoint("sts"),
         "dynamodb_endpoint": get_service_endpoint("dynamodb"),
+        "use_path_style": bool(use_s3_path_style()),
     }
     configs.update(backend_config)
     get_or_create_bucket(configs["bucket"])


### PR DESCRIPTION
I'm seeing this error when I try running `tflocal` within a docker container with an s3 backend:
```
Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.
Error refreshing state: RequestError: send request failed
caused by: Get "http://my-bucket-tfstate.localstack:4566/uat/uat.tfstate": dial tcp: lookup my-bucket-tfstate.localstack on 127.0.0.11:53: lame referral
```

This is happening because the s3 backend code is missing the `s3_use_path_style` [logic that's already in the provider overrides](https://github.com/localstack/terraform-local/blob/38be70bac8b11f31d93dcd06134a2c28cb144841/bin/tflocal#L132). 

Unfortunately force_path_style is currently deprecated in favor of use_path_style, but I'm not seeing a mechanism for checking terraform version and switching between the two. That probably needs to be added in another PR, so I'm using `force_path_style` for the most compatibility for now.