### PR TITLE
Update Setuptools to exclude tests during packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ please refer to the man pages of `terraform --help`.
 
 ## Change Log
 
+* v0.16.1: Update Setuptools to exclude tests during packaging
 * v0.16.0: Introducing semantic versioning and AWS_ENDPOINT_URL variable
 * v0.15: Update endpoint overrides for Terraform AWS provider 5.22.0
 * v0.14: Add support to multi-account environments

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.16.0
+version = 0.16.1
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud
@@ -34,3 +34,7 @@ test =
     flake8
     localstack
     pytest
+
+[options.packages.find]
+exclude =
+    tests*


### PR DESCRIPTION
# Motivation

I installed tflocal to my project and noticed that my absolute import within my tests directory was getting overriden by a tests directory found within my `.venv/libs/python/site-packages` directory. This pull request makes a minor update to the setup.cfg to exclude this project's unit tests from the distributable.

# Evidence
Before, the content of the .tar.gz dist with a tests directory
![image](https://github.com/localstack/terraform-local/assets/5365325/6d00c561-435f-4e4e-a979-7683ccde4138)

After, the content of the .tar.gz dist without a tests directory
![image](https://github.com/localstack/terraform-local/assets/5365325/90fddef3-95a2-4be8-9b61-ed5e84d152a2)
