### PR TITLE
Options to always generate a new config file or ignore an existing one

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The following environment variables can be configured:
     * `default` profile's credentials are configured
     * falls back to the default `AWS_ACCESS_KEY_ID` mock value
 * `AWS_ACCESS_KEY_ID`: AWS Access Key ID to use for multi account setups (default: `test` -> account ID: `000000000000`)
+* `ALWAYS_GENERATE`: whether to always overwrite an existing override file
+* `IGNORE_EXISTING_FILE`: whether to ignore an existing override file
 
 ## Usage
 

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -39,6 +39,8 @@ LS_PROVIDERS_FILE = os.environ.get("LS_PROVIDERS_FILE") or "localstack_providers
 LOCALSTACK_HOSTNAME = urlparse(AWS_ENDPOINT_URL).hostname or os.environ.get("LOCALSTACK_HOSTNAME") or "localhost"
 EDGE_PORT = int(urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
 TF_VERSION: Optional[version.Version] = None
+ALWAYS_GENERATE = str(os.environ.get("ALWAYS_GENERATE")).strip().lower() in ["1", "true"]
+IGNORE_EXISTING_FILE = str(os.environ.get("IGNORE_EXISTING_FILE")).strip().lower() in ["1", "true"]
 TF_PROVIDER_CONFIG = """
 provider "aws" {
   access_key                  = "<access_key>"
@@ -154,10 +156,18 @@ def create_provider_config_file(provider_aliases=None):
     # write temporary config file
     providers_file = get_providers_file_path()
     if os.path.exists(providers_file):
-        msg = f"Providers override file {providers_file} already exists - please delete it first"
-        raise Exception(msg)
-    with open(providers_file, mode="w") as fp:
-        fp.write(tf_config)
+        if ALWAYS_GENERATE:
+            os.remove(providers_file)
+            write_config_file(providers_file, tf_config)
+            return providers_file
+
+        if not IGNORE_EXISTING_FILE:
+            msg = f"Providers override file {providers_file} already exists - please delete it first"
+            raise Exception(msg)
+
+    else:
+        write_config_file(providers_file, tf_config)
+
     return providers_file
 
 
@@ -168,6 +178,11 @@ def get_providers_file_path() -> str:
     if chdir:
         base_dir = chdir[0].removeprefix("-chdir=")
     return os.path.join(base_dir, LS_PROVIDERS_FILE)
+
+
+def write_config_file(providers_file, tf_config):
+    with open(providers_file, mode="w") as fp:
+        fp.write(tf_config)
 
 
 def determine_provider_aliases() -> list:


### PR DESCRIPTION
### Motivation

We've recently been using `tflocal` and found it frustrating while debugging that we would have to constantly manually delete the existing override file before running `tflocal` commands.

This PR adds a few lines and extra options to help alleviate this pain point. 

### Changes

* adds `ALWAYS_GENERATE` env variable to determine whether to delete the existing config file and generate a new one each run
* adds `IGNORE_EXISTING_FILE` env variable to determine whether to raise an exception or not if an existing config file exists
* break the config file writing functionality into its own method for DRY
* update README documentation with the new options