### PR TITLE
Add dry_run and fix s3 backend merging behaviour

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,10 @@ jobs:
       uses: actions/checkout@v3
     - name: Pull LocalStack Docker image
       run: docker pull localstack/localstack &
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install dependencies
       run: make install
     - name: Run code linter

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ pip install terraform-local
 ## Configurations
 
 The following environment variables can be configured:
+* `DRY_RUN`: Generate the override file without invoking Terraform
 * `TF_CMD`: Terraform command to call (default: `terraform`)
 * `AWS_ENDPOINT_URL`: hostname and port of the target LocalStack instance
 * `LOCALSTACK_HOSTNAME`: __(Deprecated)__ host name of the target LocalStack instance
@@ -48,6 +49,7 @@ please refer to the man pages of `terraform --help`.
 
 ## Change Log
 
+* v0.18.0: Add `DRY_RUN` and patch S3 backend entrypoints
 * v0.17.1: Add `packaging` module to install requirements
 * v0.17.0: Add option to use new endpoints S3 backend options
 * v0.16.1: Update Setuptools to exclude tests during packaging

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -36,6 +36,7 @@ LOCALHOST_HOSTNAME = "localhost.localstack.cloud"
 S3_HOSTNAME = os.environ.get("S3_HOSTNAME") or f"s3.{LOCALHOST_HOSTNAME}"
 USE_EXEC = str(os.environ.get("USE_EXEC")).strip().lower() in ["1", "true"]
 TF_CMD = os.environ.get("TF_CMD") or "terraform"
+TF_PROXIED_CMDS = ("init", "plan", "apply", "destroy")
 LS_PROVIDERS_FILE = os.environ.get("LS_PROVIDERS_FILE") or "localstack_providers_override.tf"
 LOCALSTACK_HOSTNAME = urlparse(AWS_ENDPOINT_URL).hostname or os.environ.get("LOCALSTACK_HOSTNAME") or "localhost"
 EDGE_PORT = int(urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
@@ -401,6 +402,11 @@ def get_or_create_ddb_table(table_name: str, region: str = None):
 # ---
 # TF UTILS
 # ---
+def is_override_needed(args) -> bool:
+    if any(map(lambda x: x in args, TF_PROXIED_CMDS)):
+        return True
+    return False
+
 
 def parse_tf_files() -> dict:
     """Parse the local *.tf files and return a dict of <filename> -> <resource_dict>"""
@@ -476,22 +482,26 @@ def main():
         print(f"Unable to determine version. See error message for details: {e}")
         exit(1)
 
-    check_override_file(get_providers_file_path())
+    if is_override_needed(sys.argv[1:]):
+        check_override_file(get_providers_file_path())
 
-    # create TF provider config file
-    providers = determine_provider_aliases()
-    config_file = create_provider_config_file(providers)
+        # create TF provider config file
+        providers = determine_provider_aliases()
+        config_file = create_provider_config_file(providers)
 
-    # call terraform command
-    if not DRY_RUN:
+    # call terraform command if not dry-run or any of the commands
+    if not DRY_RUN or (DRY_RUN and not is_override_needed(sys.argv[1:])):
         try:
             if USE_EXEC:
                 run_tf_exec(cmd, env)
             else:
                 run_tf_subprocess(cmd, env)
         finally:
-            os.remove(config_file)
-
+            try:
+                os.remove(config_file)
+            except UnboundLocalError:
+                # fall through if haven't set during dry-run
+                pass
 
 if __name__ == "__main__":
     main()

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -503,5 +503,6 @@ def main():
                 # fall through if haven't set during dry-run
                 pass
 
+
 if __name__ == "__main__":
     main()

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -191,7 +191,7 @@ def determine_provider_aliases() -> list:
 
 def generate_s3_backend_config() -> str:
     """Generate an S3 `backend {..}` block with local endpoints, if configured"""
-    is_tf_legacy = not (TF_VERSION.major > 1 or (TF_VERSION.major == 1 and TF_VERSION.minor > 5))
+    is_tf_legacy = TF_VERSION < version.Version("1.6")
     backend_config = None
     tf_files = parse_tf_files()
     for filename, obj in tf_files.items():
@@ -230,7 +230,8 @@ def generate_s3_backend_config() -> str:
     }
     # Merge in legacy endpoint configs if not existing already
     if is_tf_legacy and backend_config.get("endpoints"):
-        raise ValueError("Warning: Unsupported backend options detected (`endpoints`). Please make sure you always use the corresponding options to your Terraform version.")
+        print("Warning: Unsupported backend option(s) detected (`endpoints`). Please make sure you always use the corresponding options to your Terraform version.")
+        exit(1)
     for legacy_endpoint, endpoint in legacy_endpoint_mappings.items():
         if legacy_endpoint in backend_config and (not backend_config.get("endpoints") or endpoint not in backend_config["endpoints"]):
             if not backend_config.get("endpoints"):
@@ -239,7 +240,7 @@ def generate_s3_backend_config() -> str:
     # Add any missing default endpoints
     if backend_config.get("endpoints"):
         backend_config["endpoints"] = {
-            k: (backend_config["endpoints"][k] if backend_config["endpoints"].get(k) else v)
+            k: backend_config["endpoints"].get(k) or v
             for k, v in configs["endpoints"].items()}
     configs.update(backend_config)
     if not DRY_RUN:
@@ -269,22 +270,18 @@ def generate_s3_backend_config() -> str:
     return result
 
 
-def check_override_file(providers_file):
+def check_override_file(providers_file: str) -> None:
     """Checks override file existance"""
-    try:
-        if os.path.exists(providers_file):
-            msg = f"Providers override file {providers_file} already exists"
-            err_msg = msg + " - please delete it first"
-            if DRY_RUN:
-                msg += ". File will be overwritten."
-                print(msg)
-                print("\tOnly 'yes' will be accepted to approve.")
-                if input("\tEnter a value: ") != "yes":
-                    raise FileExistsError(err_msg)
-            else:
-                raise FileExistsError(err_msg)
-    except FileExistsError as e:
-        print(e)
+    if os.path.exists(providers_file):
+        msg = f"Providers override file {providers_file} already exists"
+        err_msg = msg + " - please delete it first, exiting..."
+        if DRY_RUN:
+            msg += ". File will be overwritten."
+            print(msg)
+            print("\tOnly 'yes' will be accepted to approve.")
+            if input("\tEnter a value: ") == "yes":
+                return
+        print(err_msg)
         exit(1)
 
 
@@ -490,20 +487,20 @@ def main():
         # create TF provider config file
         providers = determine_provider_aliases()
         config_file = create_provider_config_file(providers)
+    else:
+        config_file = None
 
     # call terraform command if not dry-run or any of the commands
-    if not DRY_RUN or (DRY_RUN and not is_override_needed(sys.argv[1:])):
+    if not DRY_RUN or not is_override_needed(sys.argv[1:]):
         try:
             if USE_EXEC:
                 run_tf_exec(cmd, env)
             else:
                 run_tf_subprocess(cmd, env)
         finally:
-            try:
+            # fall through if haven't set during dry-run
+            if config_file:
                 os.remove(config_file)
-            except UnboundLocalError:
-                # fall through if haven't set during dry-run
-                pass
 
 
 if __name__ == "__main__":

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -191,6 +191,7 @@ def determine_provider_aliases() -> list:
 
 def generate_s3_backend_config() -> str:
     """Generate an S3 `backend {..}` block with local endpoints, if configured"""
+    is_tf_legacy = not (TF_VERSION.major > 1 or (TF_VERSION.major == 1 and TF_VERSION.minor > 5))
     backend_config = None
     tf_files = parse_tf_files()
     for filename, obj in tf_files.items():
@@ -228,6 +229,8 @@ def generate_s3_backend_config() -> str:
         },
     }
     # Merge in legacy endpoint configs if not existing already
+    if is_tf_legacy and backend_config.get("endpoints"):
+        raise ValueError("Warning: Unsupported backend options detected (`endpoints`). Please make sure you always use the corresponding options to your Terraform version.")
     for legacy_endpoint, endpoint in legacy_endpoint_mappings.items():
         if legacy_endpoint in backend_config and (not backend_config.get("endpoints") or endpoint not in backend_config["endpoints"]):
             if not backend_config.get("endpoints"):
@@ -247,7 +250,6 @@ def generate_s3_backend_config() -> str:
         if isinstance(value, bool):
             value = str(value).lower()
         elif isinstance(value, dict):
-            is_tf_legacy = not (TF_VERSION.major > 1 or (TF_VERSION.major == 1 and TF_VERSION.minor > 5))
             if key == "endpoints" and is_tf_legacy:
                 value = textwrap.indent(
                     text=textwrap.dedent(f"""\

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -192,7 +192,9 @@ def generate_s3_backend_config() -> str:
     """Generate an S3 `backend {..}` block with local endpoints, if configured"""
     backend_config = None
     tf_files = parse_tf_files()
-    for obj in tf_files.values():
+    for filename, obj in tf_files.items():
+        if LS_PROVIDERS_FILE == filename:
+            continue
         tf_configs = ensure_list(obj.get("terraform", []))
         for tf_config in tf_configs:
             backend_config = ensure_list(tf_config.get("backend"))
@@ -202,6 +204,13 @@ def generate_s3_backend_config() -> str:
     backend_config = backend_config and backend_config.get("s3")
     if not backend_config:
         return ""
+
+    legacy_endpoint_mappings = {
+        "endpoint": "s3",
+        "iam_endpoint": "iam",
+        "sts_endpoint": "sts",
+        "dynamodb_endpoint": "dynamodb",
+    }
 
     configs = {
         # note: default values, updated by `backend_config` further below...
@@ -217,6 +226,17 @@ def generate_s3_backend_config() -> str:
             "dynamodb": get_service_endpoint("dynamodb"),
         },
     }
+    # Merge in legacy endpoint configs if not existing already
+    for legacy_endpoint, endpoint in legacy_endpoint_mappings.items():
+        if legacy_endpoint in backend_config and (not backend_config.get("endpoints") or endpoint not in backend_config["endpoints"]):
+            if not backend_config.get("endpoints"):
+                backend_config["endpoints"] = {}
+            backend_config["endpoints"].update({endpoint: backend_config[legacy_endpoint]})
+    # Add any missing default endpoints
+    if backend_config.get("endpoints"):
+        backend_config["endpoints"] = {
+            k: (backend_config["endpoints"][k] if backend_config["endpoints"].get(k) else v)
+            for k, v in configs["endpoints"].items()}
     configs.update(backend_config)
     get_or_create_bucket(configs["bucket"])
     get_or_create_ddb_table(configs["dynamodb_table"], region=configs["region"])

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -27,6 +27,7 @@ if os.path.isdir(os.path.join(PARENT_FOLDER, ".venv")):
 from localstack_client import config  # noqa: E402
 import hcl2  # noqa: E402
 
+DRY_RUN = str(os.environ.get("DRY_RUN")).strip().lower() in ["1", "true"]
 DEFAULT_REGION = "us-east-1"
 DEFAULT_ACCESS_KEY = "test"
 AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL")
@@ -153,12 +154,15 @@ def create_provider_config_file(provider_aliases=None):
 
     # write temporary config file
     providers_file = get_providers_file_path()
-    if os.path.exists(providers_file):
-        msg = f"Providers override file {providers_file} already exists - please delete it first"
-        raise Exception(msg)
+    write_provider_config_file(providers_file, tf_config)
+
+    return providers_file
+
+
+def write_provider_config_file(providers_file, tf_config):
+    """Write provider config into file"""
     with open(providers_file, mode="w") as fp:
         fp.write(tf_config)
-    return providers_file
 
 
 def get_providers_file_path() -> str:
@@ -239,6 +243,25 @@ def generate_s3_backend_config() -> str:
             value = str(value)
         result = result.replace(f"<{key}>", value)
     return result
+
+
+def check_override_file(providers_file):
+    """Checks override file existance"""
+    try:
+        if os.path.exists(providers_file):
+            msg = f"Providers override file {providers_file} already exists"
+            err_msg = msg + " - please delete it first"
+            if DRY_RUN:
+                msg += ". File will be overwritten."
+                print(msg)
+                print("\tOnly 'yes' will be accepted to approve.")
+                if input("\tEnter a value: ") != "yes":
+                    raise FileExistsError(err_msg)
+            else:
+                raise FileExistsError(err_msg)
+    except FileExistsError as e:
+        print(e)
+        exit(1)
 
 
 # ---
@@ -432,18 +455,21 @@ def main():
         print(f"Unable to determine version. See error message for details: {e}")
         exit(1)
 
+    check_override_file(get_providers_file_path())
+
     # create TF provider config file
     providers = determine_provider_aliases()
     config_file = create_provider_config_file(providers)
 
     # call terraform command
-    try:
-        if USE_EXEC:
-            run_tf_exec(cmd, env)
-        else:
-            run_tf_subprocess(cmd, env)
-    finally:
-        os.remove(config_file)
+    if not DRY_RUN:
+        try:
+            if USE_EXEC:
+                run_tf_exec(cmd, env)
+            else:
+                run_tf_subprocess(cmd, env)
+        finally:
+            os.remove(config_file)
 
 
 if __name__ == "__main__":

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -238,8 +238,9 @@ def generate_s3_backend_config() -> str:
             k: (backend_config["endpoints"][k] if backend_config["endpoints"].get(k) else v)
             for k, v in configs["endpoints"].items()}
     configs.update(backend_config)
-    get_or_create_bucket(configs["bucket"])
-    get_or_create_ddb_table(configs["dynamodb_table"], region=configs["region"])
+    if not DRY_RUN:
+        get_or_create_bucket(configs["bucket"])
+        get_or_create_ddb_table(configs["dynamodb_table"], region=configs["region"])
     result = TF_S3_BACKEND_CONFIG
     for key, value in configs.items():
         if isinstance(value, bool):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.17.1
+version = 0.18.0
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     License :: OSI Approved :: Apache Software License
     Topic :: Software Development :: Testing
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -219,7 +219,7 @@ def test_dry_run(monkeypatch):
       bucket = "%s"
     }
     """ % (state_bucket, state_table, bucket_name)
-    is_legacy_tf = is_legacy_tf_version(get_tf_version())
+    is_legacy_tf = is_legacy_tf_version(get_version())
 
     temp_dir = deploy_tf_script(config, cleanup=False, user_input="yes")
     override_file = os.path.join(temp_dir, "localstack_providers_override.tf")
@@ -277,7 +277,7 @@ def test_s3_backend_endpoints_merge(monkeypatch, endpoints: str):
       bucket = "%s"
     }
     """ % (state_bucket, state_table, endpoints, bucket_name)
-    is_legacy_tf = is_legacy_tf_version(get_tf_version())
+    is_legacy_tf = is_legacy_tf_version(get_version())
     if is_legacy_tf:
         match endpoints:
             case "":
@@ -343,7 +343,7 @@ def is_legacy_tf_version(version, major: int = 1, minor: int = 5) -> bool:
     return False
 
 
-def get_tf_version():
+def get_version():
     """Get Terraform version"""
     output = run([TFLOCAL_BIN, "version", "-json"]).decode("utf-8")
     return version.parse(json.loads(output)["terraform_version"])

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -218,7 +218,7 @@ def test_dry_run(monkeypatch):
     temp_dir = deploy_tf_script(config, cleanup=False, user_input="yes")
     override_file = os.path.join(temp_dir, "localstack_providers_override.tf")
     assert os.path.isfile(override_file)
-    assert "b9b9f76e20227844bd98d80c56c71d37" == md5(open(override_file, 'rb').read()).hexdigest()
+    assert md5(open(override_file, 'rb').read()).hexdigest() in ("6abd2c4e92bb0ca0ae827b2a070486b8", "b9b9f76e20227844bd98d80c56c71d37")
     rmtree(temp_dir)
 
     # assert that bucket with state file exists

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -289,7 +289,7 @@ def test_s3_backend_endpoints_merge(monkeypatch, endpoints: str):
                 assert not check_override_file_format(override_file)
                 rmtree(temp_dir)
             case 'endpoint = "http://s3-localhost.localstack.cloud:4566"':
-                override_file_hash = "ee9c2ee41cf0eaad05d259dfc44cc35c" # expected file hash for TF <= v1.5
+                override_file_hash = "ee9c2ee41cf0eaad05d259dfc44cc35c"  # expected file hash for TF <= v1.5
                 temp_dir = deploy_tf_script(config, cleanup=False, user_input="yes")
                 override_file = os.path.join(temp_dir, "localstack_providers_override.tf")
                 assert check_override_file_exists(override_file)
@@ -303,7 +303,7 @@ def test_s3_backend_endpoints_merge(monkeypatch, endpoints: str):
         if endpoints == "":
             override_file_hash = "582e08b55273a6939801dfa47b597f0f"  # expected file hash for TF > v1.5
         else:
-            override_file_hash = "9518640c9106f63325fb1cc7d20041b9"
+            override_file_hash = "9518640c9106f63325fb1cc7d20041b9"  # expected file hash for TF > v1.5
         temp_dir = deploy_tf_script(config, cleanup=False, user_input="yes")
         override_file = os.path.join(temp_dir, "localstack_providers_override.tf")
         assert check_override_file_exists(override_file)
@@ -311,11 +311,14 @@ def test_s3_backend_endpoints_merge(monkeypatch, endpoints: str):
         assert check_override_file_format(override_file)
         rmtree(temp_dir)
 
+
 def check_override_file_exists(override_file):
     return os.path.isfile(override_file)
 
+
 def check_override_file_content(override_file, override_file_hash):
     return md5(open(override_file, 'rb').read()).hexdigest() == override_file_hash
+
 
 def check_override_file_format(override_file):
     try:
@@ -327,9 +330,11 @@ def check_override_file_format(override_file):
 
     return "endpoints" in result and "endpoint" not in result
 
+
 ###
 # UTIL FUNCTIONS
 ###
+
 
 def is_legacy_tf_version(version, major: int = 1, minor: int = 5) -> bool:
     """Check if Terraform version is legacy"""

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -199,6 +199,7 @@ def test_s3_backend():
     result = s3.head_bucket(Bucket=bucket_name)
     assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
 
+
 def test_dry_run(monkeypatch):
     monkeypatch.setenv("DRY_RUN", "1")
     state_bucket = "tf-state-dry-run"
@@ -225,9 +226,9 @@ def test_dry_run(monkeypatch):
     assert os.path.isfile(override_file)
 
     if is_legacy_tf:
-        override_file_hash = "6abd2c4e92bb0ca0ae827b2a070486b8" # expected file hash for TF <= v1.5
+        override_file_hash = "6abd2c4e92bb0ca0ae827b2a070486b8"  # expected file hash for TF <= v1.5
     else:
-        override_file_hash = "b9b9f76e20227844bd98d80c56c71d37" # expected file hash for TF > v1.5
+        override_file_hash = "b9b9f76e20227844bd98d80c56c71d37"  # expected file hash for TF > v1.5
 
     assert md5(open(override_file, 'rb').read()).hexdigest() == override_file_hash
 
@@ -246,6 +247,7 @@ def test_dry_run(monkeypatch):
     s3 = client("s3")
     with pytest.raises(s3.exceptions.ClientError):
         s3.head_bucket(Bucket=bucket_name)
+
 
 @pytest.mark.parametrize("endpoints", [
     '',
@@ -283,14 +285,14 @@ def test_s3_backend_endpoints_merge(monkeypatch, endpoints: str):
 
     if endpoints == "":
         if is_legacy_tf:
-            override_file_hash = "ddfba3546c869f0aa76c46887078d74c" # expected file hash for TF <= v1.5
+            override_file_hash = "ddfba3546c869f0aa76c46887078d74c"  # expected file hash for TF <= v1.5
         else:
-            override_file_hash = "582e08b55273a6939801dfa47b597f0f" # expected file hash for TF > v1.5
+            override_file_hash = "582e08b55273a6939801dfa47b597f0f"  # expected file hash for TF > v1.5
     else:
         if is_legacy_tf:
-            override_file_hash = "ee9c2ee41cf0eaad05d259dfc44cc35c" # expected file hash for TF <= v1.5
+            override_file_hash = "ee9c2ee41cf0eaad05d259dfc44cc35c"  # expected file hash for TF <= v1.5
         else:
-            override_file_hash = "9518640c9106f63325fb1cc7d20041b9" # expected file hash for TF > v1.5
+            override_file_hash = "9518640c9106f63325fb1cc7d20041b9"  # expected file hash for TF > v1.5
 
     assert md5(open(override_file, 'rb').read()).hexdigest() == override_file_hash
 
@@ -299,7 +301,7 @@ def test_s3_backend_endpoints_merge(monkeypatch, endpoints: str):
             result = hcl2.load(fp)
             result = result["terraform"][0]["backend"][0]["s3"]
     except Exception as e:
-        print(f'Unable to parse "{override_file}" as HCL file: {e}')#
+        print(f'Unable to parse "{override_file}" as HCL file: {e}')
     finally:
         rmtree(temp_dir)
 
@@ -327,15 +329,19 @@ def test_s3_backend_endpoints_merge(monkeypatch, endpoints: str):
 # UTIL FUNCTIONS
 ###
 
+
 def is_legacy_tf_version(version, major: int = 1, minor: int = 5) -> bool:
-    # Check if Terraform version is legacy
+    """Check if Terraform version is legacy"""
     if version.major < major or (version.major == major and version.minor <= minor):
         return True
     return False
 
+
 def get_tf_version():
+    """Get Terraform version"""
     output = run([TFLOCAL_BIN, "version", "-json"]).decode("utf-8")
     return version.parse(json.loads(output)["terraform_version"])
+
 
 def deploy_tf_script(script: str, cleanup: bool = True, env_vars: Dict[str, str] = None, user_input: str = None):
     with tempfile.TemporaryDirectory(delete=cleanup) as temp_dir:


### PR DESCRIPTION
# Motivation
- a frequently requested feature from users to be able to generate the override file for debugging purposes
- noticed by some users that the s3 backend endpoints generation was faulty

## Dry run
- set via `DRY_RUN` env variable
- if unset:
  - if the override file exists, tflocal throws an exception
  - if the override file not existing, tflocal creates override file and calls Terraform
- if set:
  - if the override file not existing, tflocal generates the override file and exits
  - if the override file exists, prompts user to confirm overwrite and only then generates override file

## S3 backend endpoints behaviour
### Old behaviour
1. if `endpoints` block defined, uses that even if its incomplete
2. if legacy endpoint options (`endpoint`,`sts_endpoint`...etc) are present in the original file and Terraform >v1.5 it ignores these options
3. if none of the above are present generates the right endpoints config for the used Terraform version

### New behaviour

Terraform version >1.5:

1. if `endpoints` is present: 
    1. and complete, uses that
    2. and incomplete:
        1. and legacy options are present, adds legacy options and then the missing defaults
        2. and legacy options are not present, adds the missing defaults
2. if legacy options are present:
    1. and no `endpoints` set, uses `1.ii.a.` behaviour
    2. and `endpoints` are set, see behaviour at endpoints

Terraform version <=1.5:
- only the legacy options accepted, if any of them missing we set the defaults
- for new options we throw exception and exit

From the created data structure according to the Terraform version generates the right s3 backend config:
- Terraform version >1.5, `endpoints` block
- Terraform version <=1.5, legacy options

# Changes
- [x] add `DRY_RUN` env variable
- [x] add dry run behaviour
- [x] early check for override file
- [x] fix s3 backend `endpoints` behaviour
- [x] fix s3 backend legacy options merging
- [x] add tests for s3 backend options
- [x] add tests for dry run