### PR TITLE
Service endpoint alias fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         exclude:
           - tool: tofu
             version: '1.5.7'
-    timeout-minutes: 60
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         exclude:
           - tool: tofu
             version: '1.5.7'
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
       AWS_DEFAULT_REGION: us-east-1

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ please refer to the man pages of `terraform --help`.
 
 ## Change Log
 
+* v0.18.2: Fix warning on aliased custom endpoint names
 * v0.18.1: Fix issue with not proxied commands
 * v0.18.0: Add `DRY_RUN` and patch S3 backend entrypoints
 * v0.17.1: Add `packaging` module to install requirements

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -70,6 +70,73 @@ terraform {
 }
 """
 PROCESS = None
+# some services have aliases which are mutually exclusive to each other
+# see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/custom-service-endpoints#available-endpoint-customizations
+SERVICE_ALIASES = [
+    ("amp", "prometheus", "prometheusservice"),
+    ("appautoscaling", "applicationautoscaling"),
+    ("appintegrations", "appintegrationsservice"),
+    ("ce", "costexplorer"),
+    ("cloudcontrol", "cloudcontrolapi"),
+    ("cloudhsmv2", "cloudhsm"),
+    ("cognitoidp", "cognitoidentityprovider"),
+    ("configservice", "config"),
+    ("cur", "costandusagereportservice"),
+    ("deploy", "codedeploy"),
+    ("dms", "databasemigration", "databasemigrationservice"),
+    ("ds", "directoryservice"),
+    ("elasticbeanstalk", "beanstalk"),
+    ("elasticsearch", "es", "elasticsearchservice"),
+    ("elb", "elasticloadbalancing"),
+    ("elbv2", "elasticloadbalancingv2"),
+    ("events", "eventbridge", "cloudwatchevents"),
+    ("evidently", "cloudwatchevidently"),
+    ("grafana", "managedgrafana", "amg"),
+    ("inspector2", "inspectorv2"),
+    ("kafka", "msk"),
+    ("lexmodels", "lexmodelbuilding", "lexmodelbuildingservice", "lex"),
+    ("lexv2models", "lexmodelsv2"),
+    ("location", "locationservice"),
+    ("logs", "cloudwatchlog", "cloudwatchlogs"),
+    ("oam", "cloudwatchobservabilityaccessmanager"),
+    ("opensearch", "opensearchservice"),
+    ("osis", "opensearchingestion"),
+    ("rbin", "recyclebin"),
+    ("redshiftdata", "redshiftdataapiservice"),
+    ("resourcegroupstaggingapi", "resourcegroupstagging"),
+    ("rum", "cloudwatchrum"),
+    ("s3", "s3api"),
+    ("serverlessrepo", "serverlessapprepo", "serverlessapplicationrepository"),
+    ("servicecatalogappregistry", "appregistry"),
+    ("sfn", "stepfunctions"),
+    ("simpledb", "sdb"),
+    ("transcribe", "transcribeservice"),
+]
+# service names to be excluded (not yet available in TF)
+SERVICE_EXCLUSIONS = ["meteringmarketplace"]
+# maps services to be replaced with alternative names
+# skip services which do not have equivalent endpoint overrides
+# see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/custom-service-endpoints
+SERVICE_REPLACEMENTS = {
+    "apigatewaymanagementapi": "",
+    "appconfigdata": "",
+    "ce": "costexplorer",
+    "dynamodbstreams": "",
+    "edge": "",
+    "emrserverless": "",
+    "iotdata": "",
+    "ioteventsdata": "",
+    "iotjobsdata": "",
+    "iotwireless": "",
+    "logs": "cloudwatchlogs",
+    "mediastoredata": "",
+    "qldbsession": "",
+    "rdsdata": "",
+    "sagemakerruntime": "",
+    "support": "",
+    "timestream": "",
+    "timestreamquery": "",
+}
 
 
 # ---
@@ -79,79 +146,14 @@ PROCESS = None
 def create_provider_config_file(provider_aliases=None):
     provider_aliases = provider_aliases or []
 
-    # maps services to be replaced with alternative names
-    # skip services which do not have equivalent endpoint overrides
-    # see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/custom-service-endpoints
-    service_replaces = {
-        "apigatewaymanagementapi": "",
-        "appconfigdata": "",
-        "ce": "costexplorer",
-        "dynamodbstreams": "",
-        "edge": "",
-        "emrserverless": "",
-        "iotdata": "",
-        "ioteventsdata": "",
-        "iotjobsdata": "",
-        "iotwireless": "",
-        "logs": "cloudwatchlogs",
-        "mediastoredata": "",
-        "qldbsession": "",
-        "rdsdata": "",
-        "sagemakerruntime": "",
-        "support": "",
-        "timestream": "",
-        "timestreamquery": "",
-    }
-    # service names to be excluded (not yet available in TF)
-    service_excludes = ["meteringmarketplace"]
-    service_alias_pairs = [
-        ("amp", "prometheus", "prometheusservice"),
-        ("appautoscaling", "applicationautoscaling"),
-        ("appintegrations", "appintegrationsservice"),
-        ("ce", "costexplorer"),
-        ("cloudcontrol", "cloudcontrolapi"),
-        ("cloudhsmv2", "cloudhsm"),
-        ("cognitoidp", "cognitoidentityprovider"),
-        ("configservice", "config"),
-        ("cur", "costandusagereportservice"),
-        ("deploy", "codedeploy"),
-        ("dms", "databasemigration", "databasemigrationservice"),
-        ("ds", "directoryservice"),
-        ("elasticbeanstalk", "beanstalk"),
-        ("elasticsearch", "es", "elasticsearchservice"),
-        ("elb", "elasticloadbalancing"),
-        ("elbv2", "elasticloadbalancingv2"),
-        ("events", "eventbridge", "cloudwatchevents"),
-        ("evidently", "cloudwatchevidently"),
-        ("grafana", "managedgrafana", "amg"),
-        ("inspector2", "inspectorv2"),
-        ("kafka", "msk"),
-        ("lexmodels", "lexmodelbuilding", "lexmodelbuildingservice", "lex"),
-        ("lexv2models", "lexmodelsv2"),
-        ("location", "locationservice"),
-        ("logs", "cloudwatchlog", "cloudwatchlogs"),
-        ("oam", "cloudwatchobservabilityaccessmanager"),
-        ("opensearch", "opensearchservice"),
-        ("osis", "opensearchingestion"),
-        ("rbin", "recyclebin"),
-        ("redshiftdata", "redshiftdataapiservice"),
-        ("resourcegroupstaggingapi", "resourcegroupstagging"),
-        ("rum", "cloudwatchrum"),
-        ("s3", "s3api"),
-        ("serverlessrepo", "serverlessapprepo", "serverlessapplicationrepository"),
-        ("servicecatalogappregistry", "appregistry"),
-        ("sfn", "stepfunctions"),
-        ("simpledb", "sdb"),
-        ("transcribe", "transcribeservice"),
-    ]
     # Force service alias replacements
-    service_replaces.update({alias: alias_pairs[0] for alias_pairs in service_alias_pairs for alias in alias_pairs if alias != alias_pairs[0]})
+    SERVICE_REPLACEMENTS.update({alias: alias_pairs[0] for alias_pairs in SERVICE_ALIASES for alias in alias_pairs if alias != alias_pairs[0]})
 
     # create list of service names
     services = list(config.get_service_ports())
-    services = [srvc for srvc in services if srvc not in service_excludes]
+    services = [srvc for srvc in services if srvc not in SERVICE_EXCLUSIONS]
     services = [s.replace("-", "") for s in services]
-    for old, new in service_replaces.items():
+    for old, new in SERVICE_REPLACEMENTS.items():
         try:
             services.remove(old)
             if new and new not in services:

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -104,6 +104,48 @@ def create_provider_config_file(provider_aliases=None):
     }
     # service names to be excluded (not yet available in TF)
     service_excludes = ["meteringmarketplace"]
+    service_alias_pairs = [
+        ("amp", "prometheus", "prometheusservice"),
+        ("appautoscaling", "applicationautoscaling"),
+        ("appintegrations", "appintegrationsservice"),
+        ("ce", "costexplorer"),
+        ("cloudcontrol", "cloudcontrolapi"),
+        ("cloudhsmv2", "cloudhsm"),
+        ("cognitoidp", "cognitoidentityprovider"),
+        ("configservice", "config"),
+        ("cur", "costandusagereportservice"),
+        ("deploy", "codedeploy"),
+        ("dms", "databasemigration", "databasemigrationservice"),
+        ("ds", "directoryservice"),
+        ("elasticbeanstalk", "beanstalk"),
+        ("elasticsearch", "es", "elasticsearchservice"),
+        ("elb", "elasticloadbalancing"),
+        ("elbv2", "elasticloadbalancingv2"),
+        ("events", "eventbridge", "cloudwatchevents"),
+        ("evidently", "cloudwatchevidently"),
+        ("grafana", "managedgrafana", "amg"),
+        ("inspector2", "inspectorv2"),
+        ("kafka", "msk"),
+        ("lexmodels", "lexmodelbuilding", "lexmodelbuildingservice", "lex"),
+        ("lexv2models", "lexmodelsv2"),
+        ("location", "locationservice"),
+        ("logs", "cloudwatchlog", "cloudwatchlogs"),
+        ("oam", "cloudwatchobservabilityaccessmanager"),
+        ("opensearch", "opensearchservice"),
+        ("osis", "opensearchingestion"),
+        ("rbin", "recyclebin"),
+        ("redshiftdata", "redshiftdataapiservice"),
+        ("resourcegroupstaggingapi", "resourcegroupstagging"),
+        ("rum", "cloudwatchrum"),
+        ("s3", "s3api"),
+        ("serverlessrepo", "serverlessapprepo", "serverlessapplicationrepository"),
+        ("servicecatalogappregistry", "appregistry"),
+        ("sfn", "stepfunctions"),
+        ("simpledb", "sdb"),
+        ("transcribe", "transcribeservice"),
+    ]
+    # Force service alias replacements
+    service_replaces.update({alias: alias_pairs[0] for alias_pairs in service_alias_pairs for alias in alias_pairs if alias != alias_pairs[0]})
 
     # create list of service names
     services = list(config.get_service_ports())
@@ -112,7 +154,7 @@ def create_provider_config_file(provider_aliases=None):
     for old, new in service_replaces.items():
         try:
             services.remove(old)
-            if new:
+            if new and new not in services:
                 services.append(new)
         except ValueError:
             pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.18.1
+version = 0.18.2
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -262,7 +262,7 @@ def check_override_file_content(override_file):
             result = hcl2.load(fp)
             result = result["provider"][0]["aws"]
     except Exception as e:
-        print(f'Unable to parse "{override_file}" as HCL file: {e}')
+        raise Exception(f'Unable to parse "{override_file}" as HCL file: {e}')
 
     endpoints = result["endpoints"][0]
     if "config" in endpoints and "configservice" in endpoints:

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -99,7 +99,9 @@ def test_access_key_override_by_provider(monkeypatch):
 
 
 def test_s3_path_addressing():
-    bucket_name = f"bucket.{short_uid()}"
+    # Temporarily change "." -> "-" as aws provider >5.55.0 fails with LocalStack
+    # by calling aws-global pseudo region at S3 bucket creation instead of us-east-1
+    bucket_name = f"bucket-{short_uid()}"
     config = """
     resource "aws_s3_bucket" "test-bucket" {
       bucket = "%s"
@@ -164,7 +166,9 @@ def test_provider_aliases():
 def test_s3_backend():
     state_bucket = f"tf-state-{short_uid()}"
     state_table = f"tf-state-{short_uid()}"
-    bucket_name = f"bucket.{short_uid()}"
+    # Temporarily change "." -> "-" as aws provider >5.55.0 fails with LocalStack
+    # by calling aws-global pseudo region at S3 bucket creation instead of us-east-1
+    bucket_name = f"bucket-{short_uid()}"
     config = """
     terraform {
       backend "s3" {
@@ -203,7 +207,9 @@ def test_dry_run(monkeypatch):
     monkeypatch.setenv("DRY_RUN", "1")
     state_bucket = "tf-state-dry-run"
     state_table = "tf-state-dry-run"
-    bucket_name = "bucket.dry-run"
+    # Temporarily change "." -> "-" as aws provider >5.55.0 fails with LocalStack
+    # by calling aws-global pseudo region at S3 bucket creation instead of us-east-1
+    bucket_name = "bucket-dry-run"
     config = """
     terraform {
       backend "s3" {
@@ -282,7 +288,9 @@ def test_s3_backend_endpoints_merge(monkeypatch, endpoints: str):
     monkeypatch.setenv("DRY_RUN", "1")
     state_bucket = "tf-state-merge"
     state_table = "tf-state-merge"
-    bucket_name = "bucket.merge"
+    # Temporarily change "." -> "-" as aws provider >5.55.0 fails with LocalStack
+    # by calling aws-global pseudo region at S3 bucket creation instead of us-east-1
+    bucket_name = "bucket-merge"
     config = """
     terraform {
       backend "s3" {


### PR DESCRIPTION
# Motivation
Issue #55 pointed out the warning below:
```
Warning: Invalid Attribute Combination
│ 
│   with provider["registry.terraform.io/hashicorp/aws"],
│   on providers.tf line 19, in provider "aws":
│   19: provider "aws" {
│ 
│ Only one of the following attributes should be set: "endpoints[0].configservice", "endpoints[0].config"
│ 
│ This will be an error in a future release.
│ 
│ (and one more similar warning elsewhere)
```
The source of it is the generated provider file contains endpoints which are each other's aliases.

# Changes
- To resolve this we remove such duplications now with a maintained set of service endpoint aliases (see full list in [provider documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/custom-service-endpoints#appautoscaling)) and enforcing the first value in the list each time