### PR TITLE
allow to skip overrides by provider alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following environment variables can be configured:
     * `default` profile's credentials are configured
     * falls back to the default `AWS_ACCESS_KEY_ID` mock value
 * `AWS_ACCESS_KEY_ID`: AWS Access Key ID to use for multi account setups (default: `test` -> account ID: `000000000000`)
+* `SKIP_ALIASES`: Allows to skip generating AWS provider overrides for specified aliased providers, e.g. `SKIP_ALIASES=aws_secrets,real_aws`
 
 ## Usage
 
@@ -49,6 +50,7 @@ please refer to the man pages of `terraform --help`.
 
 ## Change Log
 
+* v0.19.0: Add `SKIP_ALIASES` configuration environment variable
 * v0.18.2: Fix warning on aliased custom endpoint names
 * v0.18.1: Fix issue with not proxied commands
 * v0.18.0: Add `DRY_RUN` and patch S3 backend entrypoints

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -221,12 +221,13 @@ def get_providers_file_path() -> str:
 
 def determine_provider_aliases() -> list:
     """Return a list of providers (and aliases) configured in the *.tf files (if any)"""
+    skipped = str(os.environ.get("SKIP_ALIASES") or "").strip().split(",")
     result = []
     tf_files = parse_tf_files()
     for _file, obj in tf_files.items():
         try:
             providers = ensure_list(obj.get("provider", []))
-            aws_providers = [prov["aws"] for prov in providers if prov.get("aws")]
+            aws_providers = [prov["aws"] for prov in providers if prov.get("aws") and prov.get("aws").get("alias") not in skipped]
             result.extend(aws_providers)
         except Exception as e:
             print(f"Warning: Unable to extract providers from {_file}:", e)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.18.2
+version = 0.19.0
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud


### PR DESCRIPTION
This PR adds ability to not generate overrides for AWS providers by specific aliases. The justification for this feature is that it allows to use real AWS resources for certain resources by utilizing provider aliases and localstack for others.