### PR TITLE
fix: S3 backend config detection with multiple terraform blocks

### DIFF
--- a/bin/tflocal
+++ b/bin/tflocal
@@ -269,9 +269,9 @@ def generate_s3_backend_config() -> str:
             continue
         tf_configs = ensure_list(obj.get("terraform", []))
         for tf_config in tf_configs:
-            backend_config = ensure_list(tf_config.get("backend"))
-            if backend_config:
-                backend_config = backend_config[0]
+            tmp_backend_config = ensure_list(tf_config.get("backend"))
+            if tmp_backend_config[0]:
+                backend_config = tmp_backend_config[0]
                 break
     backend_config = backend_config and backend_config.get("s3")
     if not backend_config:


### PR DESCRIPTION
## Issue

The `generate_s3_backend_config` function had a bug where it would exit the loop after finding the first terraform block with a backend configuration, ignoring any subsequent terraform blocks that might contain the actual backend configuration.

This could cause issues in configurations with multiple terraform blocks across different files, where the function might not find the correct backend configuration.

## Fix

Introduced a temporary variable `tmp_backend_config` to properly handle multiple terraform blocks. The function now correctly finds the first valid backend configuration and stops searching after that point, ensuring it doesn't miss backend configurations in subsequent terraform blocks.

## Testing

I've verified this fix works correctly with configurations that have multiple terraform blocks.

A rough test case to reproduce this issue is available in a separate branch for review. While the test code is not very clean, it demonstrates the issue and confirms the fix works as expected.

https://github.com/hazi/terraform-local/commits/reproduce_bug_in_backend_config/

https://github.com/hazi/terraform-local/blob/df3f6d0111b093a4e06a7e15e964ecea78f67a30/tests/test_apply.py#L456-L472