### PR TITLE
Fix s3 backend setting DynamoDB state lock on by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ ADDITIONAL_TF_OVERRIDE_LOCATIONS=/path/to/module1,path/to/module2 tflocal plan
 
 ## Change Log
 
+* v0.22.0: Fix S3 backend forcing DynamoDB State Lock to be enabled by default
 * v0.21.0: Add ability to drop an override file in additional locations
 * v0.20.1: Fix list config rendering
 * v0.20.0: Fix S3 backend option merging

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -288,7 +288,6 @@ def generate_s3_backend_config() -> str:
         # note: default values, updated by `backend_config` further below...
         "bucket": "tf-test-state",
         "key": "terraform.tfstate",
-        "use_lockfile": True,
         "region": get_region(),
         "skip_credentials_validation": True,
         "skip_metadata_api_check": True,
@@ -338,9 +337,7 @@ def generate_s3_backend_config() -> str:
     if not DRY_RUN:
         get_or_create_bucket(configs["bucket"])
         if "dynamodb_table" in configs:
-            del configs["use_lockfile"]
-            get_or_create_ddb_table(
-                configs["dynamodb_table"], region=configs["region"])
+            get_or_create_ddb_table(configs["dynamodb_table"], region=configs["region"])
     result = TF_S3_BACKEND_CONFIG
     config_options = ""
     for key, value in sorted(configs.items()):

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -55,7 +55,8 @@ LOCALSTACK_HOSTNAME = (
     or os.environ.get("LOCALSTACK_HOSTNAME")
     or "localhost"
 )
-EDGE_PORT = int(urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
+EDGE_PORT = int(
+    urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
 TF_VERSION: Optional[version.Version] = None
 TF_PROVIDER_CONFIG = """
 provider "aws" {
@@ -186,7 +187,8 @@ def create_provider_config_file(provider_file_path: str, provider_aliases=None) 
     for provider in provider_aliases:
         provider_config = TF_PROVIDER_CONFIG.replace(
             "<access_key>",
-            get_access_key(provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
+            get_access_key(
+                provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
         )
         endpoints = "\n".join(
             [f'    {s} = "{get_service_endpoint(s)}"' for s in services]
@@ -288,7 +290,7 @@ def generate_s3_backend_config() -> str:
         # note: default values, updated by `backend_config` further below...
         "bucket": "tf-test-state",
         "key": "terraform.tfstate",
-        "dynamodb_table": "tf-test-state",
+        "use_lockfile": True,
         "region": get_region(),
         "skip_credentials_validation": True,
         "skip_metadata_api_check": True,
@@ -332,12 +334,16 @@ def generate_s3_backend_config() -> str:
             for k, v in configs["endpoints"].items()
         }
     backend_config["access_key"] = (
-        get_access_key(backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+        get_access_key(
+            backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
     )
     configs.update(backend_config)
     if not DRY_RUN:
         get_or_create_bucket(configs["bucket"])
-        get_or_create_ddb_table(configs["dynamodb_table"], region=configs["region"])
+        if "dynamodb_table" in configs:
+            del configs["use_lockfile"]
+            get_or_create_ddb_table(
+                configs["dynamodb_table"], region=configs["region"])
     result = TF_S3_BACKEND_CONFIG
     config_options = ""
     for key, value in sorted(configs.items()):
@@ -491,7 +497,8 @@ def get_or_create_bucket(bucket_name: str):
         region = s3_client.meta.region_name
         kwargs = {}
         if region != "us-east-1":
-            kwargs = {"CreateBucketConfiguration": {"LocationConstraint": region}}
+            kwargs = {"CreateBucketConfiguration": {
+                "LocationConstraint": region}}
         return s3_client.create_bucket(Bucket=bucket_name, **kwargs)
 
 
@@ -505,7 +512,8 @@ def get_or_create_ddb_table(table_name: str, region: str = None):
             TableName=table_name,
             BillingMode="PAY_PER_REQUEST",
             KeySchema=[{"AttributeName": "LockID", "KeyType": "HASH"}],
-            AttributeDefinitions=[{"AttributeName": "LockID", "AttributeType": "S"}],
+            AttributeDefinitions=[
+                {"AttributeName": "LockID", "AttributeType": "S"}],
         )
 
 
@@ -615,7 +623,8 @@ def main():
         if not TF_VERSION:
             raise ValueError
     except (FileNotFoundError, ValueError) as e:
-        print(f"Unable to determine version. See error message for details: {e}")
+        print(
+            f"Unable to determine version. See error message for details: {e}")
         exit(1)
 
     config_override_files = []

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -55,8 +55,7 @@ LOCALSTACK_HOSTNAME = (
     or os.environ.get("LOCALSTACK_HOSTNAME")
     or "localhost"
 )
-EDGE_PORT = int(
-    urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
+EDGE_PORT = int(urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
 TF_VERSION: Optional[version.Version] = None
 TF_PROVIDER_CONFIG = """
 provider "aws" {
@@ -187,8 +186,7 @@ def create_provider_config_file(provider_file_path: str, provider_aliases=None) 
     for provider in provider_aliases:
         provider_config = TF_PROVIDER_CONFIG.replace(
             "<access_key>",
-            get_access_key(
-                provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
+            get_access_key(provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
         )
         endpoints = "\n".join(
             [f'    {s} = "{get_service_endpoint(s)}"' for s in services]
@@ -334,8 +332,7 @@ def generate_s3_backend_config() -> str:
             for k, v in configs["endpoints"].items()
         }
     backend_config["access_key"] = (
-        get_access_key(
-            backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+        get_access_key(backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
     )
     configs.update(backend_config)
     if not DRY_RUN:
@@ -497,8 +494,7 @@ def get_or_create_bucket(bucket_name: str):
         region = s3_client.meta.region_name
         kwargs = {}
         if region != "us-east-1":
-            kwargs = {"CreateBucketConfiguration": {
-                "LocationConstraint": region}}
+            kwargs = {"CreateBucketConfiguration": {"LocationConstraint": region}}
         return s3_client.create_bucket(Bucket=bucket_name, **kwargs)
 
 
@@ -512,8 +508,7 @@ def get_or_create_ddb_table(table_name: str, region: str = None):
             TableName=table_name,
             BillingMode="PAY_PER_REQUEST",
             KeySchema=[{"AttributeName": "LockID", "KeyType": "HASH"}],
-            AttributeDefinitions=[
-                {"AttributeName": "LockID", "AttributeType": "S"}],
+            AttributeDefinitions=[{"AttributeName": "LockID", "AttributeType": "S"}],
         )
 
 
@@ -623,8 +618,7 @@ def main():
         if not TF_VERSION:
             raise ValueError
     except (FileNotFoundError, ValueError) as e:
-        print(
-            f"Unable to determine version. See error message for details: {e}")
+        print(f"Unable to determine version. See error message for details: {e}")
         exit(1)
 
     config_override_files = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.21.0
+version = 0.22.0
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud


### PR DESCRIPTION
For some reason my dynamoDB config is constantly being clobbered and even with the creation of the default lock table, I keep getting non existent table errors from tflocal, and it's blocking my on boarding as a new enterprise customer.

Since DynamoDB is deprecated anyways, here's support for `use_lockfile` which is the new standard and simply uses an object in the state s3 bucket to handle locking. 

This PR switches to use_lockfile as the new standard config, and if someone wants to override it with a bucket config, we yank out use_lockfile and throw their table into the previous logic path of get_or_create on the table they have configured.

Let me know if there's any fixes you'd like added, but I think its pretty solid.

https://developer.hashicorp.com/terraform/language/backend/s3#enabling-s3-state-locking