### PR TITLE
Add support for remote state blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ fabric.properties
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/pycharm+all,visualstudiocode
+.venv/

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ ADDITIONAL_TF_OVERRIDE_LOCATIONS=/path/to/module1,path/to/module2 tflocal plan
 
 ## Change Log
 
+* v0.22.0: Fix S3 backend forcing DynamoDB State Lock to be enabled by default
 * v0.21.0: Add ability to drop an override file in additional locations
 * v0.20.1: Fix list config rendering
 * v0.20.0: Fix S3 backend option merging

--- a/README.md
+++ b/README.md
@@ -42,14 +42,42 @@ The following environment variables can be configured:
     * falls back to the default `AWS_ACCESS_KEY_ID` mock value
 * `AWS_ACCESS_KEY_ID`: AWS Access Key ID to use for multi account setups (default: `test` -> account ID: `000000000000`)
 * `SKIP_ALIASES`: Allows to skip generating AWS provider overrides for specified aliased providers, e.g. `SKIP_ALIASES=aws_secrets,real_aws`
+* `ADDITIONAL_TF_OVERRIDE_LOCATIONS`: Comma-separated list of folder paths that will also receive a temporary `localstack_providers_override.tf` file
 
 ## Usage
 
 The `tflocal` command has the same usage as the `terraform` command. For detailed usage,
 please refer to the man pages of `terraform --help`.
 
+### Validation errors when using local terraform modules
+
+Note that if your project uses local terraform modules, and those modules reference providers, those folders *also* need to receive a temporary `localstack_providers_override.tf` file. Without it, you would get an error that looks like this when starting to process code from inside the module
+
+```
+╷
+│ Error: No valid credential sources found
+│ 
+│   with module.lambda.provider["registry.terraform.io/hashicorp/aws"],
+│   on ../../providers.tf line 11, in provider "aws":
+│   11: provider "aws" {
+│ 
+│ Please see https://registry.terraform.io/providers/hashicorp/aws
+│ for more information about providing credentials.
+│ 
+│ Error: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, access disabled to EC2 IMDS via client option, or "AWS_EC2_METADATA_DISABLED" environment variable
+```
+
+To address this issue, you may include a comma-separated list of folder paths that will recieve additional override files via an environment variable
+
+```
+ADDITIONAL_TF_OVERRIDE_LOCATIONS=/path/to/module1,path/to/module2 tflocal plan
+```
+
+[See this issue for more discussion](https://github.com/localstack/terraform-local/issues/67)
+
 ## Change Log
 
+* v0.21.0: Add ability to drop an override file in additional locations
 * v0.20.1: Fix list config rendering
 * v0.20.0: Fix S3 backend option merging
 * v0.19.0: Add `SKIP_ALIASES` configuration environment variable

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ ADDITIONAL_TF_OVERRIDE_LOCATIONS=/path/to/module1,path/to/module2 tflocal plan
 
 ## Change Log
 
+* v0.23.0: Add support for `terraform_remote_state` with `s3` backend to read the state stored in local S3 backend; fix S3 backend config detection with multiple Terraform blocks
 * v0.22.0: Fix S3 backend forcing DynamoDB State Lock to be enabled by default
 * v0.21.0: Add ability to drop an override file in additional locations
 * v0.20.1: Fix list config rendering

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -410,14 +410,14 @@ def _generate_s3_backend_config(backend_config: Dict) -> Tuple[Dict, str]:
     # Update with user-provided configs
     default_config.update(backend_config)
     # Generate config string
-    config_options = ""
+    config_string = ""
     for key, value in sorted(default_config.items()):
         if isinstance(value, bool):
             value = str(value).lower()
         elif isinstance(value, dict):
             if key == "endpoints" and is_tf_legacy:
                 for legacy_endpoint, endpoint in legacy_endpoint_mappings.items():
-                    config_options += f'\n    {legacy_endpoint} = "{default_config[key][endpoint]}"'
+                    config_string += f'\n    {legacy_endpoint} = "{default_config[key][endpoint]}"'
                 continue
             else:
                 joined_values = "\n".join([f'  {k} = "{v}"' for k, v in value.items()])
@@ -425,7 +425,7 @@ def _generate_s3_backend_config(backend_config: Dict) -> Tuple[Dict, str]:
                     text=f"{key} = {{\n{joined_values}\n}}",
                     prefix=" " * 4,
                 )
-                config_options += f"\n{value}"
+                config_string += f"\n{value}"
                 continue
         elif isinstance(value, list):
             # TODO this will break if it's a list of dicts or other complex object
@@ -434,9 +434,9 @@ def _generate_s3_backend_config(backend_config: Dict) -> Tuple[Dict, str]:
             value = f"[{', '.join(as_string)}]"
         else:
             value = f'"{str(value)}"'
-        config_options += f"\n    {key} = {value}"
+        config_string += f"\n    {key} = {value}"
 
-    return config_options
+    return default_config, config_string
 
 
 def check_override_file(providers_file: str) -> None:

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -18,7 +18,7 @@ import textwrap
 
 from packaging import version
 from urllib.parse import urlparse
-from typing import Iterable, Optional, Dict
+from typing import Iterable, Optional, Dict, Tuple
 
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 if os.path.isdir(os.path.join(PARENT_FOLDER, ".venv")):
@@ -288,33 +288,16 @@ def generate_s3_backend_config() -> str:
     if not s3_backend_config:
         return ""
 
-    backend_default_config = {
-        # note: default values, updated by `backend_config` further below...
-        "bucket": "tf-test-state",
-        "key": "terraform.tfstate",
-        "region": get_region(),
-        "skip_credentials_validation": True,
-        "skip_metadata_api_check": True,
-        "secret_key": "test",
-        "endpoints": {
-            "s3": get_service_endpoint("s3"),
-            "iam": get_service_endpoint("iam"),
-            "sso": get_service_endpoint("sso"),
-            "sts": get_service_endpoint("sts"),
-            "dynamodb": get_service_endpoint("dynamodb"),
-        },
-    }
-
-    config_options = _generate_s3_backend_config(s3_backend_config, backend_default_config)
+    config_values, config_string = _generate_s3_backend_config(s3_backend_config)
     if not DRY_RUN:
-        get_or_create_bucket(backend_default_config["bucket"])
-        if "dynamodb_table" in backend_default_config:
+        get_or_create_bucket(config_values["bucket"])
+        if "dynamodb_table" in config_values:
             get_or_create_ddb_table(
-                backend_default_config["dynamodb_table"],
-                region=backend_default_config["region"],
+                config_values["dynamodb_table"],
+                region=config_values["region"],
             )
 
-    result = TF_S3_BACKEND_CONFIG.replace("<configs>", config_options)
+    result = TF_S3_BACKEND_CONFIG.replace("<configs>", config_string)
     return result
 
 
@@ -349,42 +332,43 @@ def generate_remote_state_config() -> str:
                         workspace = f'"{workspace}"'
                     workspace = f"workspace = {workspace}"
 
-                # Set up default configs
-                remote_state_default_config = {
-                    "bucket": "tf-test-state",
-                    "key": "terraform.tfstate",
-                    "region": get_region(),
-                    "skip_credentials_validation": True,
-                    "skip_metadata_api_check": True,
-                    "secret_key": "test",
-                    "endpoints": {
-                        "s3": get_service_endpoint("s3"),
-                        "iam": get_service_endpoint("iam"),
-                        "sso": get_service_endpoint("sso"),
-                        "sts": get_service_endpoint("sts"),
-                    },
-                }
-
-                config_options = _generate_s3_backend_config(backend_config, remote_state_default_config)
+                _, config_str = _generate_s3_backend_config(backend_config)
 
                 # Create the final config
                 remote_state_config = TF_REMOTE_STATE_CONFIG.replace(
                     "<name>", data_name
                 ) \
-                    .replace("<configs>", config_options) \
+                    .replace("<configs>", config_str) \
                     .replace("<workspace-placeholder>", workspace)
                 result += remote_state_config
 
     return result
 
 
-def _generate_s3_backend_config(backend_config: Dict, default_config: Dict) -> str:
+def _generate_s3_backend_config(backend_config: Dict) -> Tuple[Dict, str]:
     is_tf_legacy = TF_VERSION < version.Version("1.6")
     legacy_endpoint_mappings = {
         "endpoint": "s3",
         "iam_endpoint": "iam",
         "sts_endpoint": "sts",
         "dynamodb_endpoint": "dynamodb",
+    }
+
+    # Set up default config
+    default_config = {
+        "bucket": "tf-test-state",
+        "key": "terraform.tfstate",
+        "region": get_region(),
+        "skip_credentials_validation": True,
+        "skip_metadata_api_check": True,
+        "secret_key": "test",
+        "endpoints": {
+            "s3": get_service_endpoint("s3"),
+            "iam": get_service_endpoint("iam"),
+            "sso": get_service_endpoint("sso"),
+            "sts": get_service_endpoint("sts"),
+            "dynamodb": get_service_endpoint("dynamodb"),
+        },
     }
 
     # Merge in legacy endpoint configs if not existing already

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -350,8 +350,7 @@ def generate_s3_backend_config() -> str:
     if not DRY_RUN:
         get_or_create_bucket(configs["bucket"])
         if "dynamodb_table" in configs:
-            get_or_create_ddb_table(
-                configs["dynamodb_table"], region=configs["region"])
+            get_or_create_ddb_table(configs["dynamodb_table"], region=configs["region"])
     result = TF_S3_BACKEND_CONFIG
     config_options = ""
     for key, value in sorted(configs.items()):

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -405,7 +405,10 @@ def _generate_s3_backend_config(backend_config: Dict, default_config: Dict) -> s
 
     # Add any missing default endpoints
     if backend_config.get("endpoints"):
-        default_config["endpoints"].update(backend_config["endpoints"])
+        backend_config["endpoints"] = {
+            k: backend_config["endpoints"].get(k) or v
+            for k, v in default_config["endpoints"].items()
+        }
 
     backend_config["access_key"] = (
         get_access_key(backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -18,7 +18,7 @@ import textwrap
 
 from packaging import version
 from urllib.parse import urlparse
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Dict
 
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 if os.path.isdir(os.path.join(PARENT_FOLDER, ".venv")):
@@ -271,30 +271,23 @@ def determine_provider_aliases() -> list:
 
 def generate_s3_backend_config() -> str:
     """Generate an S3 `backend {..}` block with local endpoints, if configured"""
-    is_tf_legacy = TF_VERSION < version.Version("1.6")
-    backend_config = None
+    s3_backend_config = {}
     tf_files = parse_tf_files()
     for filename, obj in tf_files.items():
         if LS_PROVIDERS_FILE == filename:
             continue
         tf_configs = ensure_list(obj.get("terraform", []))
         for tf_config in tf_configs:
-            backend_config = ensure_list(tf_config.get("backend"))
-            if backend_config:
-                backend_config = backend_config[0]
-                break
-    backend_config = backend_config and backend_config.get("s3")
-    if not backend_config:
+            if tf_config.get("backend"):
+                backend_config = ensure_list(tf_config.get("backend"))[0]
+                if backend_config.get("s3"):
+                    s3_backend_config = backend_config["s3"]
+                    break
+
+    if not s3_backend_config:
         return ""
 
-    legacy_endpoint_mappings = {
-        "endpoint": "s3",
-        "iam_endpoint": "iam",
-        "sts_endpoint": "sts",
-        "dynamodb_endpoint": "dynamodb",
-    }
-
-    configs = {
+    backend_default_config = {
         # note: default values, updated by `backend_config` further below...
         "bucket": "tf-test-state",
         "key": "terraform.tfstate",
@@ -310,74 +303,17 @@ def generate_s3_backend_config() -> str:
             "dynamodb": get_service_endpoint("dynamodb"),
         },
     }
-    # Merge in legacy endpoint configs if not existing already
-    if is_tf_legacy and backend_config.get("endpoints"):
-        print(
-            "Warning: Unsupported backend option(s) detected (`endpoints`). Please make sure you always use the corresponding options to your Terraform version."
-        )
-        exit(1)
-    for legacy_endpoint, endpoint in legacy_endpoint_mappings.items():
-        if (
-            legacy_endpoint in backend_config
-            and backend_config.get("endpoints")
-            and endpoint in backend_config["endpoints"]
-        ):
-            del backend_config[legacy_endpoint]
-            continue
-        if legacy_endpoint in backend_config and (
-            not backend_config.get("endpoints")
-            or endpoint not in backend_config["endpoints"]
-        ):
-            if not backend_config.get("endpoints"):
-                backend_config["endpoints"] = {}
-            backend_config["endpoints"].update(
-                {endpoint: backend_config[legacy_endpoint]}
-            )
-            del backend_config[legacy_endpoint]
-    # Add any missing default endpoints
-    if backend_config.get("endpoints"):
-        backend_config["endpoints"] = {
-            k: backend_config["endpoints"].get(k) or v
-            for k, v in configs["endpoints"].items()
-        }
-    backend_config["access_key"] = (
-        get_access_key(backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
-    )
-    configs.update(backend_config)
+
+    config_options = _generate_s3_backend_config(s3_backend_config, backend_default_config)
     if not DRY_RUN:
-        get_or_create_bucket(configs["bucket"])
-        if "dynamodb_table" in configs:
-            get_or_create_ddb_table(configs["dynamodb_table"], region=configs["region"])
-    result = TF_S3_BACKEND_CONFIG
-    config_options = ""
-    for key, value in sorted(configs.items()):
-        if isinstance(value, bool):
-            value = str(value).lower()
-        elif isinstance(value, dict):
-            if key == "endpoints" and is_tf_legacy:
-                for legacy_endpoint, endpoint in legacy_endpoint_mappings.items():
-                    config_options += (
-                        f'\n    {legacy_endpoint} = "{configs[key][endpoint]}"'
-                    )
-                continue
-            else:
-                value = textwrap.indent(
-                    text=f"{key} = {{\n"
-                    + "\n".join([f'  {k} = "{v}"' for k, v in value.items()])
-                    + "\n}",
-                    prefix=" " * 4,
-                )
-                config_options += f"\n{value}"
-                continue
-        elif isinstance(value, list):
-            # TODO this will break if it's a list of dicts or other complex object
-            # this serialization logic should probably be moved to a separate recursive function
-            as_string = [f'"{item}"' for item in value]
-            value = f"[{', '.join(as_string)}]"
-        else:
-            value = f'"{str(value)}"'
-        config_options += f"\n    {key} = {value}"
-    result = result.replace("<configs>", config_options)
+        get_or_create_bucket(backend_default_config["bucket"])
+        if "dynamodb_table" in backend_default_config:
+            get_or_create_ddb_table(
+                backend_default_config["dynamodb_table"],
+                region=backend_default_config["region"],
+            )
+
+    result = TF_S3_BACKEND_CONFIG.replace("<configs>", config_options)
     return result
 
 
@@ -387,15 +323,7 @@ def generate_remote_state_config() -> str:
     Similar to generate_s3_backend_config but for terraform_remote_state blocks.
     """
 
-    is_tf_legacy = TF_VERSION < version.Version("1.6")
     tf_files = parse_tf_files()
-
-    legacy_endpoint_mappings = {
-        "endpoint": "s3",
-        "iam_endpoint": "iam",
-        "sts_endpoint": "sts",
-        "dynamodb_endpoint": "dynamodb",
-    }
 
     result = ""
     for filename, obj in tf_files.items():
@@ -410,39 +338,18 @@ def generate_remote_state_config() -> str:
                 if data_config.get("backend") != "s3":
                     continue
                 # Create override for S3 remote state
-                config_attrs = data_config.get("config", {})
-                if not config_attrs:
+                backend_config = data_config.get("config", {})
+                if not backend_config:
                     continue
-                # Merge in legacy endpoint configs if not existing already
-                if is_tf_legacy and config_attrs.get("endpoints"):
-                    print(
-                        "Warning: Unsupported backend option(s) detected (`endpoints`). Please make sure you always use the corresponding options to your Terraform version."
-                    )
-                    exit(1)
-                for legacy_endpoint, endpoint in legacy_endpoint_mappings.items():
-                    if (
-                        legacy_endpoint in config_attrs
-                        and config_attrs.get("endpoints")
-                        and endpoint in config_attrs["endpoints"]
-                    ):
-                        del config_attrs[legacy_endpoint]
-                        continue
-                    if legacy_endpoint in config_attrs and (
-                        not config_attrs.get("endpoints")
-                        or endpoint not in config_attrs["endpoints"]
-                    ):
-                        if not config_attrs.get("endpoints"):
-                            config_attrs["endpoints"] = {}
-                        config_attrs["endpoints"].update(
-                            {endpoint: config_attrs[legacy_endpoint]}
-                        )
-                        del config_attrs[legacy_endpoint]
 
                 # Set up default configs
-                configs = {
-                    "bucket": config_attrs.get("bucket", "tf-test-state"),
-                    "key": config_attrs.get("key", "terraform.tfstate"),
-                    "region": config_attrs.get("region", get_region()),
+                remote_state_default_config = {
+                    "bucket": "tf-test-state",
+                    "key": "terraform.tfstate",
+                    "region": get_region(),
+                    "skip_credentials_validation": True,
+                    "skip_metadata_api_check": True,
+                    "secret_key": "test",
                     "endpoints": {
                         "s3": get_service_endpoint("s3"),
                         "iam": get_service_endpoint("iam"),
@@ -451,63 +358,93 @@ def generate_remote_state_config() -> str:
                     },
                 }
 
-                # Add any missing default endpoints
-                if config_attrs.get("endpoints"):
-                    config_attrs["endpoints"] = {
-                        k: config_attrs["endpoints"].get(k) or v
-                        for k, v in configs["endpoints"].items()
-                    }
-
-                # Update with user-provided configs
-                configs.update(config_attrs)
-
-                # Generate config string
-                config_options = ""
-                for key, value in sorted(configs.items()):
-                    if isinstance(value, bool):
-                        value = str(value).lower()
-                    elif isinstance(value, dict):
-                        if key == "endpoints" and is_tf_legacy:
-                            for (
-                                legacy_endpoint,
-                                endpoint,
-                            ) in legacy_endpoint_mappings.items():
-                                config_options += f'\n    {legacy_endpoint} = "{configs[key][endpoint]}"'
-                            continue
-                        else:
-                            value = textwrap.indent(
-                                text=f"{key} = {{\n"
-                                + "\n".join(
-                                    [f'  {k} = "{v}"' for k, v in value.items()]
-                                )
-                                + "\n}",
-                                prefix=" " * 4,
-                            )
-                            config_options += f"\n{value}"
-                            continue
-                    elif isinstance(value, list):
-                        # TODO this will break if it's a list of dicts or other complex object
-                        # this serialization logic should probably be moved to a separate recursive function
-                        as_string = [f'"{item}"' for item in value]
-                        value = f"[{', '.join(as_string)}]"
-                    else:
-                        value = f'"{str(value)}"'
-                    config_options += f"\n    {key} = {value}"
+                config_options = _generate_s3_backend_config(backend_config, remote_state_default_config)
 
                 # Create the final config
                 remote_state_config = TF_REMOTE_STATE_CONFIG.replace(
                     "<name>", data_name
-                )
-                remote_state_config = remote_state_config.replace(
-                    "<configs>", config_options
-                )
+                ).replace("<configs>", config_options)
                 result += remote_state_config
 
     return result
 
 
+def _generate_s3_backend_config(backend_config: Dict, default_config: Dict) -> str:
+    is_tf_legacy = TF_VERSION < version.Version("1.6")
+    legacy_endpoint_mappings = {
+        "endpoint": "s3",
+        "iam_endpoint": "iam",
+        "sts_endpoint": "sts",
+        "dynamodb_endpoint": "dynamodb",
+    }
+
+    # Merge in legacy endpoint configs if not existing already
+    if is_tf_legacy and backend_config.get("endpoints"):
+        print(
+            "Warning: Unsupported backend option(s) detected (`endpoints`). Please make sure you always use the corresponding options to your Terraform version."
+        )
+        exit(1)
+    for legacy_endpoint, endpoint in legacy_endpoint_mappings.items():
+        if (
+                legacy_endpoint in backend_config
+                and backend_config.get("endpoints")
+                and endpoint in backend_config["endpoints"]
+        ):
+            del backend_config[legacy_endpoint]
+            continue
+        if legacy_endpoint in backend_config and (
+                not backend_config.get("endpoints")
+                or endpoint not in backend_config["endpoints"]
+        ):
+            if not backend_config.get("endpoints"):
+                backend_config["endpoints"] = {}
+            backend_config["endpoints"].update(
+                {endpoint: backend_config[legacy_endpoint]}
+            )
+            del backend_config[legacy_endpoint]
+
+    # Add any missing default endpoints
+    if backend_config.get("endpoints"):
+        default_config["endpoints"].update(backend_config["endpoints"])
+
+    backend_config["access_key"] = (
+        get_access_key(backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+    )
+
+    # Update with user-provided configs
+    default_config.update(backend_config)
+    # Generate config string
+    config_options = ""
+    for key, value in sorted(default_config.items()):
+        if isinstance(value, bool):
+            value = str(value).lower()
+        elif isinstance(value, dict):
+            if key == "endpoints" and is_tf_legacy:
+                for legacy_endpoint, endpoint in legacy_endpoint_mappings.items():
+                    config_options += f'\n    {legacy_endpoint} = "{default_config[key][endpoint]}"'
+                continue
+            else:
+                joined_values = "\n".join([f'  {k} = "{v}"' for k, v in value.items()])
+                value = textwrap.indent(
+                    text=f"{key} = {{\n{joined_values}\n}}",
+                    prefix=" " * 4,
+                )
+                config_options += f"\n{value}"
+                continue
+        elif isinstance(value, list):
+            # TODO this will break if it's a list of dicts or other complex object
+            # this serialization logic should probably be moved to a separate recursive function
+            as_string = [f'"{item}"' for item in value]
+            value = f"[{', '.join(as_string)}]"
+        else:
+            value = f'"{str(value)}"'
+        config_options += f"\n    {key} = {value}"
+
+    return config_options
+
+
 def check_override_file(providers_file: str) -> None:
-    """Checks override file existance"""
+    """Checks override file existence"""
     if os.path.exists(providers_file):
         msg = f"Providers override file {providers_file} already exists"
         err_msg = msg + " - please delete it first, exiting..."

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -75,6 +75,13 @@ terraform {
   }
 }
 """
+TF_REMOTE_STATE_CONFIG = """
+data "terraform_remote_state" "<name>" {
+  backend = "s3"
+  config = {<configs>
+  }
+}
+"""
 PROCESS = None
 # some services have aliases which are mutually exclusive to each other
 # see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/custom-service-endpoints#available-endpoint-customizations
@@ -214,6 +221,9 @@ def create_provider_config_file(provider_file_path: str, provider_aliases=None) 
 
     # create s3 backend config
     tf_config += generate_s3_backend_config()
+
+    # create remote state config
+    tf_config += generate_remote_state_config()
 
     # write temporary config file
     write_provider_config_file(provider_file_path, tf_config)
@@ -370,6 +380,61 @@ def generate_s3_backend_config() -> str:
     result = result.replace("<configs>", config_options)
     return result
 
+def generate_remote_state_config() -> str:
+    """
+    Generate configuration for terraform_remote_state data sources to use LocalStack endpoints.
+    Similar to generate_s3_backend_config but for terraform_remote_state blocks.
+    """
+    tf_files = parse_tf_files()
+    if not tf_files:
+        return ""
+
+    result = ""
+    for filename, obj in tf_files.items():
+        if LS_PROVIDERS_FILE == filename:
+            continue
+            
+        data_blocks = ensure_list(obj.get("data", []))
+        for data_block in data_blocks:
+            terraform_remote_state = data_block.get("terraform_remote_state")
+            if not terraform_remote_state:
+                continue
+                
+            for data_name, data_config in terraform_remote_state.items():
+                if data_config.get("backend") != "s3":
+                    continue
+                    
+                # Create override for S3 remote state
+                config_attrs = data_config.get("config", {})
+                if not config_attrs:
+                    continue
+                
+                # Set up default configs
+                configs = {
+                    "bucket": config_attrs.get("bucket", "tf-test-state"),
+                    "key": config_attrs.get("key", "terraform.tfstate"),
+                    "region": config_attrs.get("region", get_region()),
+                    "endpoint": get_service_endpoint("s3"),
+                }
+                
+                # Update with user-provided configs
+                configs.update(config_attrs)
+                
+                # Generate config string
+                config_options = ""
+                for key, value in sorted(configs.items()):
+                    if isinstance(value, bool):
+                        value = str(value).lower()
+                    elif isinstance(value, (str, int, float)):
+                        value = f'"{value}"'
+                    config_options += f'\n    {key} = {value}'
+                
+                # Create the final config
+                remote_state_config = TF_REMOTE_STATE_CONFIG.replace("<name>", data_name)
+                remote_state_config = remote_state_config.replace("<configs>", config_options)
+                result += remote_state_config
+    
+    return result
 
 def check_override_file(providers_file: str) -> None:
     """Checks override file existance"""

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -288,7 +288,6 @@ def generate_s3_backend_config() -> str:
         # note: default values, updated by `backend_config` further below...
         "bucket": "tf-test-state",
         "key": "terraform.tfstate",
-        "use_lockfile": True,
         "region": get_region(),
         "skip_credentials_validation": True,
         "skip_metadata_api_check": True,
@@ -338,9 +337,7 @@ def generate_s3_backend_config() -> str:
     if not DRY_RUN:
         get_or_create_bucket(configs["bucket"])
         if "dynamodb_table" in configs:
-            del configs["use_lockfile"]
-            get_or_create_ddb_table(
-                configs["dynamodb_table"], region=configs["region"])
+            get_or_create_ddb_table(configs["dynamodb_table"], region=configs["region"])
     result = TF_S3_BACKEND_CONFIG
     config_options = ""
     for key, value in sorted(configs.items()):

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -78,6 +78,7 @@ terraform {
 TF_REMOTE_STATE_CONFIG = """
 data "terraform_remote_state" "<name>" {
   backend = "s3"
+  <workspace-placeholder>
   config = {<configs>
   }
 }
@@ -324,7 +325,6 @@ def generate_remote_state_config() -> str:
     """
 
     tf_files = parse_tf_files()
-
     result = ""
     for filename, obj in tf_files.items():
         if LS_PROVIDERS_FILE == filename:
@@ -341,6 +341,13 @@ def generate_remote_state_config() -> str:
                 backend_config = data_config.get("config", {})
                 if not backend_config:
                     continue
+                workspace = data_config.get("workspace", "")
+                if workspace:
+                    if workspace[0] == "$":
+                        workspace = workspace.lstrip('${').rstrip('}')
+                    else:
+                        workspace = f'"{workspace}"'
+                    workspace = f"workspace = {workspace}"
 
                 # Set up default configs
                 remote_state_default_config = {
@@ -363,7 +370,9 @@ def generate_remote_state_config() -> str:
                 # Create the final config
                 remote_state_config = TF_REMOTE_STATE_CONFIG.replace(
                     "<name>", data_name
-                ).replace("<configs>", config_options)
+                ) \
+                    .replace("<configs>", config_options) \
+                    .replace("<workspace-placeholder>", workspace)
                 result += remote_state_config
 
     return result

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -18,7 +18,7 @@ import textwrap
 
 from packaging import version
 from urllib.parse import urlparse
-from typing import Optional
+from typing import Iterable, Optional
 
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 if os.path.isdir(os.path.join(PARENT_FOLDER, ".venv")):
@@ -31,14 +31,30 @@ DRY_RUN = str(os.environ.get("DRY_RUN")).strip().lower() in ["1", "true"]
 DEFAULT_REGION = "us-east-1"
 DEFAULT_ACCESS_KEY = "test"
 AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL")
-CUSTOMIZE_ACCESS_KEY = str(os.environ.get("CUSTOMIZE_ACCESS_KEY")).strip().lower() in ["1", "true"]
+CUSTOMIZE_ACCESS_KEY = str(os.environ.get("CUSTOMIZE_ACCESS_KEY")).strip().lower() in [
+    "1",
+    "true",
+]
 LOCALHOST_HOSTNAME = "localhost.localstack.cloud"
 S3_HOSTNAME = os.environ.get("S3_HOSTNAME") or f"s3.{LOCALHOST_HOSTNAME}"
 USE_EXEC = str(os.environ.get("USE_EXEC")).strip().lower() in ["1", "true"]
 TF_CMD = os.environ.get("TF_CMD") or "terraform"
-TF_UNPROXIED_CMDS = os.environ.get("TF_UNPROXIED_CMDS").split(sep=",") if os.environ.get("TF_UNPROXIED_CMDS") else ("fmt", "validate", "version")
-LS_PROVIDERS_FILE = os.environ.get("LS_PROVIDERS_FILE") or "localstack_providers_override.tf"
-LOCALSTACK_HOSTNAME = urlparse(AWS_ENDPOINT_URL).hostname or os.environ.get("LOCALSTACK_HOSTNAME") or "localhost"
+ADDITIONAL_TF_OVERRIDE_LOCATIONS = os.environ.get(
+    "ADDITIONAL_TF_OVERRIDE_LOCATIONS", default=""
+)
+TF_UNPROXIED_CMDS = (
+    os.environ.get("TF_UNPROXIED_CMDS").split(sep=",")
+    if os.environ.get("TF_UNPROXIED_CMDS")
+    else ("fmt", "validate", "version")
+)
+LS_PROVIDERS_FILE = (
+    os.environ.get("LS_PROVIDERS_FILE") or "localstack_providers_override.tf"
+)
+LOCALSTACK_HOSTNAME = (
+    urlparse(AWS_ENDPOINT_URL).hostname
+    or os.environ.get("LOCALSTACK_HOSTNAME")
+    or "localhost"
+)
 EDGE_PORT = int(urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
 TF_VERSION: Optional[version.Version] = None
 TF_PROVIDER_CONFIG = """
@@ -133,11 +149,19 @@ SERVICE_REPLACEMENTS = {
 # CONFIG GENERATION UTILS
 # ---
 
-def create_provider_config_file(provider_aliases=None):
+
+def create_provider_config_file(provider_file_path: str, provider_aliases=None) -> None:
     provider_aliases = provider_aliases or []
 
     # Force service alias replacements
-    SERVICE_REPLACEMENTS.update({alias: alias_pairs[0] for alias_pairs in SERVICE_ALIASES for alias in alias_pairs if alias != alias_pairs[0]})
+    SERVICE_REPLACEMENTS.update(
+        {
+            alias: alias_pairs[0]
+            for alias_pairs in SERVICE_ALIASES
+            for alias in alias_pairs
+            if alias != alias_pairs[0]
+        }
+    )
 
     # create list of service names
     services = list(config.get_service_ports())
@@ -162,9 +186,11 @@ def create_provider_config_file(provider_aliases=None):
     for provider in provider_aliases:
         provider_config = TF_PROVIDER_CONFIG.replace(
             "<access_key>",
-            get_access_key(provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+            get_access_key(provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
         )
-        endpoints = "\n".join([f'    {s} = "{get_service_endpoint(s)}"' for s in services])
+        endpoints = "\n".join(
+            [f'    {s} = "{get_service_endpoint(s)}"' for s in services]
+        )
         provider_config = provider_config.replace("<endpoints>", endpoints)
         additional_configs = []
         if use_s3_path_style():
@@ -178,7 +204,9 @@ def create_provider_config_file(provider_aliases=None):
         if isinstance(region, list):
             region = region[0]
         additional_configs += [f'region = "{region}"']
-        provider_config = provider_config.replace("<configs>", "\n".join(additional_configs))
+        provider_config = provider_config.replace(
+            "<configs>", "\n".join(additional_configs)
+        )
         provider_configs.append(provider_config)
 
     # construct final config file content
@@ -188,10 +216,7 @@ def create_provider_config_file(provider_aliases=None):
     tf_config += generate_s3_backend_config()
 
     # write temporary config file
-    providers_file = get_providers_file_path()
-    write_provider_config_file(providers_file, tf_config)
-
-    return providers_file
+    write_provider_config_file(provider_file_path, tf_config)
 
 
 def write_provider_config_file(providers_file, tf_config):
@@ -200,12 +225,18 @@ def write_provider_config_file(providers_file, tf_config):
         fp.write(tf_config)
 
 
-def get_providers_file_path() -> str:
-    """Determine the path under which the providers override file should be stored"""
+def get_default_provider_folder_path() -> str:
+    """Determine the folder under which the providers override file should be stored"""
     chdir = [arg for arg in sys.argv if arg.startswith("-chdir=")]
     base_dir = "."
     if chdir:
         base_dir = chdir[0].removeprefix("-chdir=")
+
+    return os.path.abspath(base_dir)
+
+
+def get_providers_file_path(base_dir) -> str:
+    """Retrieve the path under which the providers override file should be stored"""
     return os.path.join(base_dir, LS_PROVIDERS_FILE)
 
 
@@ -217,7 +248,11 @@ def determine_provider_aliases() -> list:
     for _file, obj in tf_files.items():
         try:
             providers = ensure_list(obj.get("provider", []))
-            aws_providers = [prov["aws"] for prov in providers if prov.get("aws") and prov.get("aws").get("alias") not in skipped]
+            aws_providers = [
+                prov["aws"]
+                for prov in providers
+                if prov.get("aws") and prov.get("aws").get("alias") not in skipped
+            ]
             result.extend(aws_providers)
         except Exception as e:
             print(f"Warning: Unable to extract providers from {_file}:", e)
@@ -258,7 +293,6 @@ def generate_s3_backend_config() -> str:
         "skip_credentials_validation": True,
         "skip_metadata_api_check": True,
         "secret_key": "test",
-
         "endpoints": {
             "s3": get_service_endpoint("s3"),
             "iam": get_service_endpoint("iam"),
@@ -269,23 +303,37 @@ def generate_s3_backend_config() -> str:
     }
     # Merge in legacy endpoint configs if not existing already
     if is_tf_legacy and backend_config.get("endpoints"):
-        print("Warning: Unsupported backend option(s) detected (`endpoints`). Please make sure you always use the corresponding options to your Terraform version.")
+        print(
+            "Warning: Unsupported backend option(s) detected (`endpoints`). Please make sure you always use the corresponding options to your Terraform version."
+        )
         exit(1)
     for legacy_endpoint, endpoint in legacy_endpoint_mappings.items():
-        if legacy_endpoint in backend_config and backend_config.get("endpoints") and endpoint in backend_config["endpoints"]:
+        if (
+            legacy_endpoint in backend_config
+            and backend_config.get("endpoints")
+            and endpoint in backend_config["endpoints"]
+        ):
             del backend_config[legacy_endpoint]
             continue
-        if legacy_endpoint in backend_config and (not backend_config.get("endpoints") or endpoint not in backend_config["endpoints"]):
+        if legacy_endpoint in backend_config and (
+            not backend_config.get("endpoints")
+            or endpoint not in backend_config["endpoints"]
+        ):
             if not backend_config.get("endpoints"):
                 backend_config["endpoints"] = {}
-            backend_config["endpoints"].update({endpoint: backend_config[legacy_endpoint]})
+            backend_config["endpoints"].update(
+                {endpoint: backend_config[legacy_endpoint]}
+            )
             del backend_config[legacy_endpoint]
     # Add any missing default endpoints
     if backend_config.get("endpoints"):
         backend_config["endpoints"] = {
             k: backend_config["endpoints"].get(k) or v
-            for k, v in configs["endpoints"].items()}
-    backend_config["access_key"] = get_access_key(backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+            for k, v in configs["endpoints"].items()
+        }
+    backend_config["access_key"] = (
+        get_access_key(backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+    )
     configs.update(backend_config)
     if not DRY_RUN:
         get_or_create_bucket(configs["bucket"])
@@ -298,22 +346,27 @@ def generate_s3_backend_config() -> str:
         elif isinstance(value, dict):
             if key == "endpoints" and is_tf_legacy:
                 for legacy_endpoint, endpoint in legacy_endpoint_mappings.items():
-                    config_options += f'\n    {legacy_endpoint} = "{configs[key][endpoint]}"'
+                    config_options += (
+                        f'\n    {legacy_endpoint} = "{configs[key][endpoint]}"'
+                    )
                 continue
             else:
                 value = textwrap.indent(
-                    text=f"{key} = {{\n" + "\n".join([f'  {k} = "{v}"' for k, v in value.items()]) + "\n}",
-                    prefix=" " * 4)
+                    text=f"{key} = {{\n"
+                    + "\n".join([f'  {k} = "{v}"' for k, v in value.items()])
+                    + "\n}",
+                    prefix=" " * 4,
+                )
                 config_options += f"\n{value}"
                 continue
         elif isinstance(value, list):
             # TODO this will break if it's a list of dicts or other complex object
             # this serialization logic should probably be moved to a separate recursive function
             as_string = [f'"{item}"' for item in value]
-            value = f'[{", ".join(as_string)}]'
+            value = f"[{', '.join(as_string)}]"
         else:
             value = f'"{str(value)}"'
-        config_options += f'\n    {key} = {value}'
+        config_options += f"\n    {key} = {value}"
     result = result.replace("<configs>", config_options)
     return result
 
@@ -336,6 +389,7 @@ def check_override_file(providers_file: str) -> None:
 # ---
 # AWS CLIENT UTILS
 # ---
+
 
 def use_s3_path_style() -> bool:
     """
@@ -361,6 +415,7 @@ def get_region() -> str:
         # Note that boto3 is currently not included in the dependencies, to
         # keep the library lightweight.
         import boto3
+
         region = boto3.session.Session().region_name
     except Exception:
         pass
@@ -369,7 +424,9 @@ def get_region() -> str:
 
 
 def get_access_key(provider: dict) -> str:
-    access_key = str(os.environ.get("AWS_ACCESS_KEY_ID") or provider.get("access_key", "")).strip()
+    access_key = str(
+        os.environ.get("AWS_ACCESS_KEY_ID") or provider.get("access_key", "")
+    ).strip()
     if access_key and access_key != DEFAULT_ACCESS_KEY:
         # Change live access key to mocked one
         return deactivate_access_key(access_key)
@@ -378,6 +435,7 @@ def get_access_key(provider: dict) -> str:
         # Note that boto3 is currently not included in the dependencies, to
         # keep the library lightweight.
         import boto3
+
         access_key = boto3.session.Session().get_credentials().access_key
     except Exception:
         pass
@@ -387,7 +445,7 @@ def get_access_key(provider: dict) -> str:
 
 def deactivate_access_key(access_key: str) -> str:
     """Safe guarding user from accidental live credential usage by deactivating access key IDs.
-        See more: https://docs.localstack.cloud/references/credentials/"""
+    See more: https://docs.localstack.cloud/references/credentials/"""
     return "L" + access_key[1:] if access_key[0] == "A" else access_key
 
 
@@ -413,10 +471,14 @@ def get_service_endpoint(service: str) -> str:
 
 def connect_to_service(service: str, region: str = None):
     import boto3
+
     region = region or get_region()
     return boto3.client(
-        service, endpoint_url=get_service_endpoint(service), region_name=region,
-        aws_access_key_id="test", aws_secret_access_key="test",
+        service,
+        endpoint_url=get_service_endpoint(service),
+        region_name=region,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
     )
 
 
@@ -440,9 +502,10 @@ def get_or_create_ddb_table(table_name: str, region: str = None):
         return ddb_client.describe_table(TableName=table_name)
     except Exception:
         return ddb_client.create_table(
-            TableName=table_name, BillingMode="PAY_PER_REQUEST",
+            TableName=table_name,
+            BillingMode="PAY_PER_REQUEST",
             KeySchema=[{"AttributeName": "LockID", "KeyType": "HASH"}],
-            AttributeDefinitions=[{"AttributeName": "LockID", "AttributeType": "S"}]
+            AttributeDefinitions=[{"AttributeName": "LockID", "AttributeType": "S"}],
         )
 
 
@@ -469,13 +532,15 @@ def parse_tf_files() -> dict:
 
 def get_tf_version(env):
     global TF_VERSION
-    output = subprocess.run([f"{TF_CMD}", "version", "-json"], env=env, check=True, capture_output=True).stdout.decode("utf-8")
+    output = subprocess.run(
+        [f"{TF_CMD}", "version", "-json"], env=env, check=True, capture_output=True
+    ).stdout.decode("utf-8")
     TF_VERSION = version.parse(json.loads(output)["terraform_version"])
 
 
 def run_tf_exec(cmd, env):
     """Run terraform using os.exec - can be useful as it does not require any I/O
-        handling for stdin/out/err. Does *not* allow us to perform any cleanup logic."""
+    handling for stdin/out/err. Does *not* allow us to perform any cleanup logic."""
     os.execvpe(cmd[0], cmd, env=env)
 
 
@@ -485,17 +550,40 @@ def run_tf_subprocess(cmd, env):
 
     # register signal handlers
     import signal
+
     signal.signal(signal.SIGINT, signal_handler)
 
     PROCESS = subprocess.Popen(
-        cmd, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stdout)
+        cmd, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stdout
+    )
     PROCESS.communicate()
     sys.exit(PROCESS.returncode)
+
+
+def cleanup_override_files(override_files: Iterable[str]):
+    for file_path in override_files:
+        try:
+            os.remove(file_path)
+        except Exception:
+            print(
+                f"Count not clean up '{file_path}'. This is not normally a problem but you can delete this file manually."
+            )
+
+
+def get_folder_paths_that_require_an_override_file() -> Iterable[str]:
+    if not is_override_needed(sys.argv[1:]):
+        return
+
+    yield get_default_provider_folder_path()
+    for path in ADDITIONAL_TF_OVERRIDE_LOCATIONS.split(sep=","):
+        if path.strip():
+            yield path
 
 
 # ---
 # UTIL FUNCTIONS
 # ---
+
 
 def signal_handler(sig, frame):
     PROCESS.send_signal(sig)
@@ -517,6 +605,7 @@ def to_str(obj) -> bytes:
 # MAIN ENTRYPOINT
 # ---
 
+
 def main():
     env = dict(os.environ)
     cmd = [TF_CMD] + sys.argv[1:]
@@ -529,26 +618,25 @@ def main():
         print(f"Unable to determine version. See error message for details: {e}")
         exit(1)
 
-    if is_override_needed(sys.argv[1:]):
-        check_override_file(get_providers_file_path())
+    config_override_files = []
 
-        # create TF provider config file
+    for folder_path in get_folder_paths_that_require_an_override_file():
+        config_file_path = get_providers_file_path(folder_path)
+        check_override_file(config_file_path)
+
         providers = determine_provider_aliases()
-        config_file = create_provider_config_file(providers)
-    else:
-        config_file = None
+        create_provider_config_file(config_file_path, providers)
+        config_override_files.append(config_file_path)
 
     # call terraform command if not dry-run or any of the commands
-    if not DRY_RUN or not is_override_needed(sys.argv[1:]):
+    if not DRY_RUN or not config_override_files:
         try:
             if USE_EXEC:
                 run_tf_exec(cmd, env)
             else:
                 run_tf_subprocess(cmd, env)
         finally:
-            # fall through if haven't set during dry-run
-            if config_file:
-                os.remove(config_file)
+            cleanup_override_files(config_override_files)
 
 
 if __name__ == "__main__":

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -463,12 +463,6 @@ def generate_remote_state_config() -> str:
 
                 # Generate config string
                 config_options = ""
-                # for key, value in sorted(configs.items()):
-                #    if isinstance(value, bool):
-                #        value = str(value).lower()
-                #    elif isinstance(value, (str, int, float)):
-                #        value = f'"{value}"'
-                #    config_options += f"\n    {key} = {value}"
                 for key, value in sorted(configs.items()):
                     if isinstance(value, bool):
                         value = str(value).lower()

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -55,7 +55,8 @@ LOCALSTACK_HOSTNAME = (
     or os.environ.get("LOCALSTACK_HOSTNAME")
     or "localhost"
 )
-EDGE_PORT = int(urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
+EDGE_PORT = int(
+    urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
 TF_VERSION: Optional[version.Version] = None
 TF_PROVIDER_CONFIG = """
 provider "aws" {
@@ -193,7 +194,8 @@ def create_provider_config_file(provider_file_path: str, provider_aliases=None) 
     for provider in provider_aliases:
         provider_config = TF_PROVIDER_CONFIG.replace(
             "<access_key>",
-            get_access_key(provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
+            get_access_key(
+                provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
         )
         endpoints = "\n".join(
             [f'    {s} = "{get_service_endpoint(s)}"' for s in services]
@@ -341,13 +343,15 @@ def generate_s3_backend_config() -> str:
             for k, v in configs["endpoints"].items()
         }
     backend_config["access_key"] = (
-        get_access_key(backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+        get_access_key(
+            backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
     )
     configs.update(backend_config)
     if not DRY_RUN:
         get_or_create_bucket(configs["bucket"])
         if "dynamodb_table" in configs:
-            get_or_create_ddb_table(configs["dynamodb_table"], region=configs["region"])
+            get_or_create_ddb_table(
+                configs["dynamodb_table"], region=configs["region"])
     result = TF_S3_BACKEND_CONFIG
     config_options = ""
     for key, value in sorted(configs.items()):
@@ -556,7 +560,8 @@ def get_or_create_bucket(bucket_name: str):
         region = s3_client.meta.region_name
         kwargs = {}
         if region != "us-east-1":
-            kwargs = {"CreateBucketConfiguration": {"LocationConstraint": region}}
+            kwargs = {"CreateBucketConfiguration": {
+                "LocationConstraint": region}}
         return s3_client.create_bucket(Bucket=bucket_name, **kwargs)
 
 
@@ -570,7 +575,8 @@ def get_or_create_ddb_table(table_name: str, region: str = None):
             TableName=table_name,
             BillingMode="PAY_PER_REQUEST",
             KeySchema=[{"AttributeName": "LockID", "KeyType": "HASH"}],
-            AttributeDefinitions=[{"AttributeName": "LockID", "AttributeType": "S"}],
+            AttributeDefinitions=[
+                {"AttributeName": "LockID", "AttributeType": "S"}],
         )
 
 
@@ -680,7 +686,8 @@ def main():
         if not TF_VERSION:
             raise ValueError
     except (FileNotFoundError, ValueError) as e:
-        print(f"Unable to determine version. See error message for details: {e}")
+        print(
+            f"Unable to determine version. See error message for details: {e}")
         exit(1)
 
     config_override_files = []

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -55,8 +55,7 @@ LOCALSTACK_HOSTNAME = (
     or os.environ.get("LOCALSTACK_HOSTNAME")
     or "localhost"
 )
-EDGE_PORT = int(
-    urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
+EDGE_PORT = int(urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
 TF_VERSION: Optional[version.Version] = None
 TF_PROVIDER_CONFIG = """
 provider "aws" {
@@ -194,8 +193,7 @@ def create_provider_config_file(provider_file_path: str, provider_aliases=None) 
     for provider in provider_aliases:
         provider_config = TF_PROVIDER_CONFIG.replace(
             "<access_key>",
-            get_access_key(
-                provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
+            get_access_key(provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
         )
         endpoints = "\n".join(
             [f'    {s} = "{get_service_endpoint(s)}"' for s in services]
@@ -343,8 +341,7 @@ def generate_s3_backend_config() -> str:
             for k, v in configs["endpoints"].items()
         }
     backend_config["access_key"] = (
-        get_access_key(
-            backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+        get_access_key(backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
     )
     configs.update(backend_config)
     if not DRY_RUN:
@@ -383,61 +380,137 @@ def generate_s3_backend_config() -> str:
     result = result.replace("<configs>", config_options)
     return result
 
+
 def generate_remote_state_config() -> str:
     """
     Generate configuration for terraform_remote_state data sources to use LocalStack endpoints.
     Similar to generate_s3_backend_config but for terraform_remote_state blocks.
     """
+
+    is_tf_legacy = TF_VERSION < version.Version("1.6")
     tf_files = parse_tf_files()
-    if not tf_files:
-        return ""
+
+    legacy_endpoint_mappings = {
+        "endpoint": "s3",
+        "iam_endpoint": "iam",
+        "sts_endpoint": "sts",
+        "dynamodb_endpoint": "dynamodb",
+    }
 
     result = ""
     for filename, obj in tf_files.items():
         if LS_PROVIDERS_FILE == filename:
             continue
-            
         data_blocks = ensure_list(obj.get("data", []))
         for data_block in data_blocks:
             terraform_remote_state = data_block.get("terraform_remote_state")
             if not terraform_remote_state:
                 continue
-                
             for data_name, data_config in terraform_remote_state.items():
                 if data_config.get("backend") != "s3":
                     continue
-                    
                 # Create override for S3 remote state
                 config_attrs = data_config.get("config", {})
                 if not config_attrs:
                     continue
-                
+                # Merge in legacy endpoint configs if not existing already
+                if is_tf_legacy and config_attrs.get("endpoints"):
+                    print(
+                        "Warning: Unsupported backend option(s) detected (`endpoints`). Please make sure you always use the corresponding options to your Terraform version."
+                    )
+                    exit(1)
+                for legacy_endpoint, endpoint in legacy_endpoint_mappings.items():
+                    if (
+                        legacy_endpoint in config_attrs
+                        and config_attrs.get("endpoints")
+                        and endpoint in config_attrs["endpoints"]
+                    ):
+                        del config_attrs[legacy_endpoint]
+                        continue
+                    if legacy_endpoint in config_attrs and (
+                        not config_attrs.get("endpoints")
+                        or endpoint not in config_attrs["endpoints"]
+                    ):
+                        if not config_attrs.get("endpoints"):
+                            config_attrs["endpoints"] = {}
+                        config_attrs["endpoints"].update(
+                            {endpoint: config_attrs[legacy_endpoint]}
+                        )
+                        del config_attrs[legacy_endpoint]
+
                 # Set up default configs
                 configs = {
                     "bucket": config_attrs.get("bucket", "tf-test-state"),
                     "key": config_attrs.get("key", "terraform.tfstate"),
                     "region": config_attrs.get("region", get_region()),
-                    "endpoint": get_service_endpoint("s3"),
+                    "endpoints": {
+                        "s3": get_service_endpoint("s3"),
+                        "iam": get_service_endpoint("iam"),
+                        "sso": get_service_endpoint("sso"),
+                        "sts": get_service_endpoint("sts"),
+                    },
                 }
-                
+
+                # Add any missing default endpoints
+                if config_attrs.get("endpoints"):
+                    config_attrs["endpoints"] = {
+                        k: config_attrs["endpoints"].get(k) or v
+                        for k, v in configs["endpoints"].items()
+                    }
+
                 # Update with user-provided configs
                 configs.update(config_attrs)
-                
+
                 # Generate config string
                 config_options = ""
+                # for key, value in sorted(configs.items()):
+                #    if isinstance(value, bool):
+                #        value = str(value).lower()
+                #    elif isinstance(value, (str, int, float)):
+                #        value = f'"{value}"'
+                #    config_options += f"\n    {key} = {value}"
                 for key, value in sorted(configs.items()):
                     if isinstance(value, bool):
                         value = str(value).lower()
-                    elif isinstance(value, (str, int, float)):
-                        value = f'"{value}"'
-                    config_options += f'\n    {key} = {value}'
-                
+                    elif isinstance(value, dict):
+                        if key == "endpoints" and is_tf_legacy:
+                            for (
+                                legacy_endpoint,
+                                endpoint,
+                            ) in legacy_endpoint_mappings.items():
+                                config_options += f'\n    {legacy_endpoint} = "{configs[key][endpoint]}"'
+                            continue
+                        else:
+                            value = textwrap.indent(
+                                text=f"{key} = {{\n"
+                                + "\n".join(
+                                    [f'  {k} = "{v}"' for k, v in value.items()]
+                                )
+                                + "\n}",
+                                prefix=" " * 4,
+                            )
+                            config_options += f"\n{value}"
+                            continue
+                    elif isinstance(value, list):
+                        # TODO this will break if it's a list of dicts or other complex object
+                        # this serialization logic should probably be moved to a separate recursive function
+                        as_string = [f'"{item}"' for item in value]
+                        value = f"[{', '.join(as_string)}]"
+                    else:
+                        value = f'"{str(value)}"'
+                    config_options += f"\n    {key} = {value}"
+
                 # Create the final config
-                remote_state_config = TF_REMOTE_STATE_CONFIG.replace("<name>", data_name)
-                remote_state_config = remote_state_config.replace("<configs>", config_options)
+                remote_state_config = TF_REMOTE_STATE_CONFIG.replace(
+                    "<name>", data_name
+                )
+                remote_state_config = remote_state_config.replace(
+                    "<configs>", config_options
+                )
                 result += remote_state_config
-    
+
     return result
+
 
 def check_override_file(providers_file: str) -> None:
     """Checks override file existance"""
@@ -559,8 +632,7 @@ def get_or_create_bucket(bucket_name: str):
         region = s3_client.meta.region_name
         kwargs = {}
         if region != "us-east-1":
-            kwargs = {"CreateBucketConfiguration": {
-                "LocationConstraint": region}}
+            kwargs = {"CreateBucketConfiguration": {"LocationConstraint": region}}
         return s3_client.create_bucket(Bucket=bucket_name, **kwargs)
 
 
@@ -574,8 +646,7 @@ def get_or_create_ddb_table(table_name: str, region: str = None):
             TableName=table_name,
             BillingMode="PAY_PER_REQUEST",
             KeySchema=[{"AttributeName": "LockID", "KeyType": "HASH"}],
-            AttributeDefinitions=[
-                {"AttributeName": "LockID", "AttributeType": "S"}],
+            AttributeDefinitions=[{"AttributeName": "LockID", "AttributeType": "S"}],
         )
 
 
@@ -685,8 +756,7 @@ def main():
         if not TF_VERSION:
             raise ValueError
     except (FileNotFoundError, ValueError) as e:
-        print(
-            f"Unable to determine version. See error message for details: {e}")
+        print(f"Unable to determine version. See error message for details: {e}")
         exit(1)
 
     config_override_files = []

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -55,7 +55,8 @@ LOCALSTACK_HOSTNAME = (
     or os.environ.get("LOCALSTACK_HOSTNAME")
     or "localhost"
 )
-EDGE_PORT = int(urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
+EDGE_PORT = int(
+    urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
 TF_VERSION: Optional[version.Version] = None
 TF_PROVIDER_CONFIG = """
 provider "aws" {
@@ -186,7 +187,8 @@ def create_provider_config_file(provider_file_path: str, provider_aliases=None) 
     for provider in provider_aliases:
         provider_config = TF_PROVIDER_CONFIG.replace(
             "<access_key>",
-            get_access_key(provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
+            get_access_key(
+                provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
         )
         endpoints = "\n".join(
             [f'    {s} = "{get_service_endpoint(s)}"' for s in services]
@@ -288,7 +290,7 @@ def generate_s3_backend_config() -> str:
         # note: default values, updated by `backend_config` further below...
         "bucket": "tf-test-state",
         "key": "terraform.tfstate",
-        "dynamodb_table": "tf-test-state",
+        "use_lockfile": True,
         "region": get_region(),
         "skip_credentials_validation": True,
         "skip_metadata_api_check": True,
@@ -332,12 +334,16 @@ def generate_s3_backend_config() -> str:
             for k, v in configs["endpoints"].items()
         }
     backend_config["access_key"] = (
-        get_access_key(backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+        get_access_key(
+            backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
     )
     configs.update(backend_config)
     if not DRY_RUN:
         get_or_create_bucket(configs["bucket"])
-        get_or_create_ddb_table(configs["dynamodb_table"], region=configs["region"])
+        if "dynamodb_table" in configs:
+            del configs["use_lockfile"]
+            get_or_create_ddb_table(
+                configs["dynamodb_table"], region=configs["region"])
     result = TF_S3_BACKEND_CONFIG
     config_options = ""
     for key, value in sorted(configs.items()):
@@ -491,7 +497,8 @@ def get_or_create_bucket(bucket_name: str):
         region = s3_client.meta.region_name
         kwargs = {}
         if region != "us-east-1":
-            kwargs = {"CreateBucketConfiguration": {"LocationConstraint": region}}
+            kwargs = {"CreateBucketConfiguration": {
+                "LocationConstraint": region}}
         return s3_client.create_bucket(Bucket=bucket_name, **kwargs)
 
 
@@ -505,7 +512,8 @@ def get_or_create_ddb_table(table_name: str, region: str = None):
             TableName=table_name,
             BillingMode="PAY_PER_REQUEST",
             KeySchema=[{"AttributeName": "LockID", "KeyType": "HASH"}],
-            AttributeDefinitions=[{"AttributeName": "LockID", "AttributeType": "S"}],
+            AttributeDefinitions=[
+                {"AttributeName": "LockID", "AttributeType": "S"}],
         )
 
 
@@ -615,7 +623,8 @@ def main():
         if not TF_VERSION:
             raise ValueError
     except (FileNotFoundError, ValueError) as e:
-        print(f"Unable to determine version. See error message for details: {e}")
+        print(
+            f"Unable to determine version. See error message for details: {e}")
         exit(1)
 
     config_override_files = []

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -55,8 +55,7 @@ LOCALSTACK_HOSTNAME = (
     or os.environ.get("LOCALSTACK_HOSTNAME")
     or "localhost"
 )
-EDGE_PORT = int(
-    urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
+EDGE_PORT = int(urlparse(AWS_ENDPOINT_URL).port or os.environ.get("EDGE_PORT") or 4566)
 TF_VERSION: Optional[version.Version] = None
 TF_PROVIDER_CONFIG = """
 provider "aws" {
@@ -187,8 +186,7 @@ def create_provider_config_file(provider_file_path: str, provider_aliases=None) 
     for provider in provider_aliases:
         provider_config = TF_PROVIDER_CONFIG.replace(
             "<access_key>",
-            get_access_key(
-                provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
+            get_access_key(provider) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY,
         )
         endpoints = "\n".join(
             [f'    {s} = "{get_service_endpoint(s)}"' for s in services]
@@ -334,8 +332,7 @@ def generate_s3_backend_config() -> str:
             for k, v in configs["endpoints"].items()
         }
     backend_config["access_key"] = (
-        get_access_key(
-            backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
+        get_access_key(backend_config) if CUSTOMIZE_ACCESS_KEY else DEFAULT_ACCESS_KEY
     )
     configs.update(backend_config)
     if not DRY_RUN:
@@ -497,8 +494,7 @@ def get_or_create_bucket(bucket_name: str):
         region = s3_client.meta.region_name
         kwargs = {}
         if region != "us-east-1":
-            kwargs = {"CreateBucketConfiguration": {
-                "LocationConstraint": region}}
+            kwargs = {"CreateBucketConfiguration": {"LocationConstraint": region}}
         return s3_client.create_bucket(Bucket=bucket_name, **kwargs)
 
 
@@ -512,8 +508,7 @@ def get_or_create_ddb_table(table_name: str, region: str = None):
             TableName=table_name,
             BillingMode="PAY_PER_REQUEST",
             KeySchema=[{"AttributeName": "LockID", "KeyType": "HASH"}],
-            AttributeDefinitions=[
-                {"AttributeName": "LockID", "AttributeType": "S"}],
+            AttributeDefinitions=[{"AttributeName": "LockID", "AttributeType": "S"}],
         )
 
 
@@ -623,8 +618,7 @@ def main():
         if not TF_VERSION:
             raise ValueError
     except (FileNotFoundError, ValueError) as e:
-        print(
-            f"Unable to determine version. See error message for details: {e}")
+        print(f"Unable to determine version. See error message for details: {e}")
         exit(1)
 
     config_override_files = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.20.1
+version = 0.21.0
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.22.0
+version = 0.23.0
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.21.0
+version = 0.22.0
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import subprocess
 @pytest.fixture(scope="session", autouse=True)
 def start_localstack():
     subprocess.check_output(["localstack", "start", "-d"])
+    subprocess.check_output(["localstack", "wait"])
 
     yield
 


### PR DESCRIPTION
Currently TF Local doesn't handle remote state blocks, and remote state blocks don't inherit endpoint overrides from the main backend block in terraform.

This code addition adds support for iterating over all remote state blocks, basically in the same exact manner as we grab the main backend block, and injects the endpoints needed to the configuration overrides.

I'm gonna be real, I have zero idea on how to even go about setting up pytest locally for this, let alone writing the actual unit tests, so I apologize for that part lacking. This is working well for me locally currently though, it overrides and adds in the blocks perfectly and I no longer need to specify environment variable overrides for the necessary endpoints.