### PR TITLE
fix(#82): handle provider version as list in .terraform.lock.hcl

### DIFF
--- a/bin/tflocal
+++ b/bin/tflocal
@@ -634,6 +634,9 @@ def get_provider_version_from_lock_file() -> Optional[version.Version]:
                     provider_version = provider_config.get("version")
 
     if provider_version:
+        # Patch: handle case where version is a list
+        if isinstance(provider_version, list):
+            provider_version = provider_version[0]
         AWS_PROVIDER_VERSION = version.parse(provider_version)
 
 


### PR DESCRIPTION
### Description
This PR resolves a TypeError that occurs when .terraform.lock.hcl contains the _version_ field as a string, but recent versions of Terraform may emit the value as a list. This causes a TypeError within the get_provider_version_from_lock_file() function.

### .terraform.lock.hcl content
```
provider "registry.terraform.io/hashicorp/aws" {
  version = "5.100.0"
```

### Error returned from /bin/tflocal

`TypeError: expected string or bytes-like object, got 'list'`

### Fix
This fix checks for a list and safely parses the first element if necessary.