### PR TITLE
add terraform-local version when using version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ ADDITIONAL_TF_OVERRIDE_LOCATIONS=/path/to/module1,path/to/module2 tflocal plan
 
 ## Change Log
 
+* v0.24.0: Add support to return `terraform-local` version when calling `tflocal -version` and fix AWS provider detection
 * v0.23.1: Fix endpoint overrides for Terraform AWS provider >= 6.0.0-beta2
 * v0.23.0: Add support for `terraform_remote_state` with `s3` backend to read the state stored in local S3 backend; fix S3 backend config detection with multiple Terraform blocks
 * v0.22.0: Fix S3 backend forcing DynamoDB State Lock to be enabled by default

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -640,6 +640,11 @@ def get_provider_version_from_lock_file() -> Optional[version.Version]:
         AWS_PROVIDER_VERSION = version.parse(provider_version)
 
 
+def get_tf_local_version():
+    from importlib.metadata import version
+    return version("terraform-local")
+
+
 def is_service_endpoint_supported(service_name: str) -> bool:
     if service_name not in VERSIONED_SERVICE_EXCLUSIONS or not AWS_PROVIDER_VERSION:
         return True
@@ -728,8 +733,17 @@ def main():
         print(f"Unable to determine version. See error message for details: {e}")
         exit(1)
 
-    if len(sys.argv) > 1 and sys.argv[1] != "init":
-        get_provider_version_from_lock_file()
+    if len(sys.argv) > 1:
+        if sys.argv[1] != "init":
+            get_provider_version_from_lock_file()
+        if sys.argv[1] in ("--version", "-v", "-version"):
+            try:
+                # the version flag could be something else than the 1st argument, it is possible to do
+                # `terraform init -version` and it will return the version only without init, but we should probably
+                # only support the easy case
+                print(f"terraform-local v{get_tf_local_version()}", file=sys.stderr)
+            except Exception:
+                pass
 
     config_override_files = []
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.23.1
+version = 0.24.0
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -674,6 +674,23 @@ def check_override_file_content_for_alias(override_file):
     return True
 
 
+@pytest.mark.parametrize("version_flag", ["--version", "-v", "-version"])
+def test_version_command(monkeypatch, version_flag):
+    def _run(cmd, **kwargs):
+        kwargs["stderr"] = subprocess.STDOUT
+        return subprocess.check_output(cmd, **kwargs)
+
+    with tempfile.TemporaryDirectory(delete=True) as temp_dir:
+        # we need the `terraform init` command to create a lock file, so it cannot be a `DRY_RUN`
+        output = _run([TFLOCAL_BIN, version_flag], cwd=temp_dir, env=dict(os.environ))
+        assert b"terraform-local v" in output
+
+        monkeypatch.setenv("DRY_RUN", "1")
+        output = _run([TFLOCAL_BIN, version_flag], cwd=temp_dir, env=dict(os.environ))
+
+        assert b"terraform-local v" in output
+
+
 ###
 # UTIL FUNCTIONS
 ###

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -681,7 +681,6 @@ def test_version_command(monkeypatch, version_flag):
         return subprocess.check_output(cmd, **kwargs)
 
     with tempfile.TemporaryDirectory(delete=True) as temp_dir:
-        # we need the `terraform init` command to create a lock file, so it cannot be a `DRY_RUN`
         output = _run([TFLOCAL_BIN, version_flag], cwd=temp_dir, env=dict(os.environ))
         assert b"terraform-local v" in output
 


### PR DESCRIPTION
This PR now returns the version of `terraform-local` when running `tflocal -v` (or `--version`, `-version`, all accepted by Terraform). 

This was sometimes an issue when users had a global installation of `tflocal` and one in a virtual environment, and only updated one of them. It was hard to know which version you'd be calling/using. 

We are printing to `stderr` to avoid breaking existing user setup maybe relying on `tflocal --version` returning the underlying Terraform version unmodified. 

It is not trivial to get the version without directly parsing the `setup.cfg` file, or changing the setup itself to create a `__version__` variable somewhere in the code to be imported. 

Relying on `from importlib.metadata import version` seems safe, but I'm not sure if it could import a different version than the one that is being called right now... 🤔 I doubt it
This seems to be the preferred way: https://packaging.python.org/en/latest/discussions/versioning/#runtime-version-access