### PR TITLE
pinned dependencies to current working versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,14 +28,14 @@ packages = find:
 
 install_requires =
     localstack-client
-    python-hcl2
-    packaging
+    python-hcl2==7.2.1
+    packaging==25.0
 
 [options.extras_require]
 test =
-    flake8
+    flake8==7.3.0
     localstack
-    pytest
+    pytest==8.4.1
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Resolves #85 

Pinned all dependencies (apart form localstack specific ones) to ensure updates to dependencies can be managed more carefully and prevent issues arising from broken updates to dependencies 