### PR TITLE
use build instead of setuptools to create the dist, build wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:         ## Run unit/integration tests
 
 publish:      ## Publish the library to the central PyPi repository
 	# build and upload archive
-	($(VENV_RUN) && pip install setuptools twine && ./setup.py sdist && twine upload dist/*)
+	($(VENV_RUN) && pip install build twine && python3 -m build && twine upload dist/*)
 
 clean:        ## Clean up
 	rm -rf $(VENV_DIR)


### PR DESCRIPTION
## Motivation
We currently use `setuptools` and the `sdist` command to create a source distribution before publishing the dist with twine.
But direct invocations of `setup.py` have been deprecated, and we want to publish a wheel distribution as well.
This PR switches to `build` which solves both of these issues.
Fixes #78.

## Changes
- Use `build` instead of directly invoking `setup.py` to build a source and wheel distribution before publishing.