### PR TITLE
fix hcl2 v8 compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ ADDITIONAL_TF_OVERRIDE_LOCATIONS=/path/to/module1,path/to/module2 tflocal plan
 
 ## Change Log
 
+* v0.26.0: Fix compatibility with `python-hcl2` v8+ by using `SerializationOptions(strip_string_quotes=True)` to handle quoted dict keys
 * v0.25.0: Improve `s3control` local endpoint override and respect `AWS_ENDPOINT_URL` configuration for `mwaa`
 * v0.24.1: Exclude broken `python-hcl2` version from requirements
 * v0.24.0: Add support to return `terraform-local` version when calling `tflocal -version` and fix AWS provider detection

--- a/bin/tflocal
+++ b/bin/tflocal
@@ -26,6 +26,9 @@ if os.path.isdir(os.path.join(PARENT_FOLDER, ".venv")):
 
 from localstack_client import config  # noqa: E402
 import hcl2  # noqa: E402
+from hcl2 import SerializationOptions  # noqa: E402
+
+HCL2_SERIALIZATION_OPTIONS = SerializationOptions(strip_string_quotes=True)
 
 DRY_RUN = str(os.environ.get("DRY_RUN")).strip().lower() in ["1", "true"]
 DEFAULT_REGION = "us-east-1"
@@ -611,7 +614,7 @@ def parse_tf_files() -> dict:
     for _file in glob.glob("*.tf"):
         try:
             with open(_file, "r") as fp:
-                result[_file] = hcl2.load(fp)
+                result[_file] = hcl2.load(fp, serialization_options=HCL2_SERIALIZATION_OPTIONS)
         except Exception as e:
             print(f'Unable to parse "{_file}" as HCL file: {e}')
     return result
@@ -634,7 +637,7 @@ def get_provider_version_from_lock_file() -> Optional[version.Version]:
 
     provider_version = None
     with open(lock_file, "r") as fp:
-        result = hcl2.load(fp)
+        result = hcl2.load(fp, serialization_options=HCL2_SERIALIZATION_OPTIONS)
         for provider in result.get("provider", []):
             for provider_name, provider_config in provider.items():
                 if provider_name.endswith(AWS_PROVIDER_NAME_SUFFIX):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = terraform-local
-version = 0.25.0
+version = 0.26.0
 url = https://github.com/localstack/terraform-local
 author = LocalStack Team
 author_email = info@localstack.cloud
@@ -28,7 +28,7 @@ packages = find:
 
 install_requires =
     localstack-client
-    python-hcl2!=7.3.0
+    python-hcl2>=8
     packaging
 
 [options.extras_require]


### PR DESCRIPTION
python-hcl2 released a new version that has a breaking change, see  https://github.com/amplify-education/python-hcl2/pull/287